### PR TITLE
#19: Added 'm65target' and 'model_id' fields into .cor file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,11 +436,22 @@ $(BINDIR)/mega65_ftp.osx:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/ftphelper.c Makefil
 $(BINDIR)/bitinfo:	$(TOOLDIR)/bitinfo.c Makefile 
 	$(CC) $(COPT) -g -Wall -o $(BINDIR)/bitinfo $(TOOLDIR)/bitinfo.c
 
-$(BINDIR)/bit2core:	$(TOOLDIR)/bit2core.c Makefile 
-	$(CC) -g -Wall -o $(BINDIR)/bit2core $(TOOLDIR)/bit2core.c
 
-$(BINDIR)/bit2core.exe:	$(TOOLDIR)/bit2core.c Makefile 
-	$(WINCC) $(WINCOPT) -g -Wall -o $(BINDIR)/bit2core.exe $(TOOLDIR)/bit2core.c
+# Create targets for binary (linux) and binary.exe (mingw) easily, minimising repetition
+# arg1 = target name (without .exe)
+# arg2 = pre-requisites
+define LINUX_AND_MINGW_TARGETS
+$(1): $(2)
+	$$(CC) -g -Wall -o $$@ $$(filter %.c,$$^)
+
+$(1).exe: $(2)
+	$$(WINCC) $$(WINCOPT) -g -Wall -o $$@ $$(filter %.c,$$^)
+endef
+
+# Creates 2 targets:
+# - bin/bit2core (for linux)
+# - bin/bit2core.exe (for mingw)
+$(eval $(call LINUX_AND_MINGW_TARGETS, $(BINDIR)/bit2core, $(TOOLDIR)/bit2core.c $(TOOLDIR)/version.c Makefile))
 
 $(BINDIR)/bit2mcs:	$(TOOLDIR)/bit2mcs.c Makefile 
 	$(CC) $(COPT) -g -Wall -o $(BINDIR)/bit2mcs $(TOOLDIR)/bit2mcs.c

--- a/Makefile
+++ b/Makefile
@@ -409,17 +409,31 @@ $(LIBEXECDIR)/ftphelper.bin:	$(TOOLDIR)/ftphelper.a65
 $(TOOLDIR)/ftphelper.c:	$(UTILDIR)/remotesd.prg $(TOOLDIR)/bin2c
 	$(TOOLDIR)/bin2c $(UTILDIR)/remotesd.prg helperroutine $(TOOLDIR)/ftphelper.c
 
-$(GTESTBINDIR)/mega65_ftp.test: $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
-	$(CXX) $(COPT) $(GTESTOPTS) -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
+define LINUX_AND_MINGW_GTEST_TARGETS
+$(1): $(2)
+	$$(CXX) $$(COPT) $$(GTESTOPTS) -Iinclude -o $$@ $$(filter %.c %.cpp,$$^) -lreadline -lncurses -lgtest_main -lgtest -lpthread
 
-$(GTESTBINDIR)/mega65_ftp.test.exe: $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
-	$(CXX) $(WINCOPT) $(GTESTOPTS) -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
+$(1).exe: $(2)
+	$$(CXX) $$(WINCOPT) $$(GTESTOPTS) -Iinclude -o $$@ $$(filter %.c %.cpp,$$^) -lreadline -lncurses -lgtest_main -lgtest -lpthread
+endef
 
-test: $(GTESTBINDIR)/mega65_ftp.test
+# Gives two targets of:
+# - gtest/bin/mega65_ftp.test
+# - gtest/bin/mega65_ftp.test.exe
+$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/mega65_ftp.test, $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c Makefile))
+
+# Gives two targets of:
+# - gtest/bin/bit2core.test
+# - gtest/bin/bit2core.test.exe
+$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/bit2core.test, $(GTESTDIR)/bit2core_test.cpp $(TOOLDIR)/bit2core.c $(TOOLDIR)/version.c))
+
+test: $(GTESTBINDIR)/mega65_ftp.test $(GTESTBINDIR)/bit2core.test
 	$(GTESTBINDIR)/mega65_ftp.test
+	$(GTESTBINDIR)/bit2core.test
 
-test.exe: $(GTESTBINDIR)/mega65_ftp.test.exe
+test.exe: $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTBINDIR)/bit2core.test.exe
 	$(GTESTBINDIR)/mega65_ftp.test.exe
+	$(GTESTBINDIR)/bit2core.test.exe
 
 $(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
 	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses
@@ -442,10 +456,10 @@ $(BINDIR)/bitinfo:	$(TOOLDIR)/bitinfo.c Makefile
 # arg2 = pre-requisites
 define LINUX_AND_MINGW_TARGETS
 $(1): $(2)
-	$$(CC) -g -Wall -o $$@ $$(filter %.c,$$^)
+	$$(CC) -g -Wall -Iinclude -o $$@ $$(filter %.c,$$^)
 
 $(1).exe: $(2)
-	$$(WINCC) $$(WINCOPT) -g -Wall -o $$@ $$(filter %.c,$$^)
+	$$(WINCC) $$(WINCOPT) -g -Wall -Iinclude -o $$@ $$(filter %.c,$$^)
 endef
 
 # Creates 2 targets:

--- a/gtest/bit2core_test.cpp
+++ b/gtest/bit2core_test.cpp
@@ -12,15 +12,7 @@ namespace bit2core {
 
 int call_bit2core_with_args(char* m65targetname, char* bitfile, char* corfile)
 {
-  char *argv[] = {
-    "bit2core",
-    m65targetname,
-    bitfile,
-    "core_name_field",
-    "core_version_field",
-    corfile,
-    NULL
-  };
+  char* argv[] = { "bit2core", m65targetname, bitfile, "core_name_field", "core_version_field", corfile, NULL };
   return real_main(6, argv);
 }
 
@@ -77,9 +69,8 @@ class Bit2coreTestFixture : public ::testing::Test {
 TEST_F(Bit2coreTestFixture, ShouldAddModelIdIntoHeader)
 {
 
-  char m65targetnames[][80] = {
-    "mega65r1", "mega65r2", "mega65r3", "megaphoner1", "nexys4", "nexys4ddr", "nexys4ddrwidget", "wukonga100t"
-  };
+  char m65targetnames[][80] = { "mega65r1", "mega65r2", "mega65r3", "megaphoner1", "nexys4", "nexys4ddr", "nexys4ddrwidget",
+    "wukonga100t" };
   int m65target_cnt = sizeof(m65targetnames) / sizeof(m65targetnames[0]);
 
   for (int k = 0; k < m65target_cnt; k++) {

--- a/gtest/bit2core_test.cpp
+++ b/gtest/bit2core_test.cpp
@@ -1,0 +1,82 @@
+#include "gtest/gtest.h"
+#include <stdarg.h>
+#include <stdio.h>
+
+extern int real_main(int argc, char** argv);
+extern int get_model_id(const char* m65targetname);
+extern char* find_fpga_part_from_m65targetname(const char* m65targetname);
+extern int BITSTREAM_HEADER_FPGA_PART_LOC;
+
+// my tests
+namespace bit2core {
+
+void call_bit2core_with_args(char* m65targetname, char* bitfile, char* corfile)
+{
+  char *argv[] = {
+    "bit2core",
+    m65targetname,
+    bitfile,
+    "core_name_field",
+    "core_version_field",
+    corfile,
+    NULL
+  };
+  real_main(6, argv);
+}
+
+void generate_dummy_bit_file(const char* name, const char* m65targetname)
+{
+  char* fpga_part = find_fpga_part_from_m65targetname(m65targetname);
+
+  FILE* f = fopen(name, "wb");
+  for (int i = 0; i < 10000; i++) {
+    // inject fpga-part string at appropriate location
+    if (i >= BITSTREAM_HEADER_FPGA_PART_LOC && i <= BITSTREAM_HEADER_FPGA_PART_LOC + strlen(fpga_part)) {
+      int pos = i - BITSTREAM_HEADER_FPGA_PART_LOC;
+      if (pos < strlen(fpga_part))
+        fputc(fpga_part[pos], f);
+      else
+        fputc('\0', f);
+    }
+    else
+      fputc(i % 256, f);
+  }
+  fclose(f);
+}
+
+int extract_model_id_from_core_file(const char* name)
+{
+  FILE* f = fopen(name, "rb");
+  fseek(f, 0x70, SEEK_SET);
+  int ret = fgetc(f);
+  fclose(f);
+
+  return ret;
+}
+
+
+TEST(Bit2coreTest, ShouldAddModelIdIntoHeader)
+{
+  char m65targetnames[][80] = {
+    "mega65r1", "mega65r2", "mega65r3", "megaphoner1", "nexys4", "nexys4ddr", "nexys4ddrwidget", "wukonga100t"
+  };
+  int m65target_cnt = sizeof(m65targetnames) / sizeof(m65targetnames[0]);
+
+  for (int k = 0; k < m65target_cnt; k++) {
+    generate_dummy_bit_file("foo.bit", m65targetnames[k]);
+
+    int expected_model_id = get_model_id(m65targetnames[k]);
+
+    call_bit2core_with_args(m65targetnames[k], "foo.bit", "foo.cor");
+
+    int actual_model_id = extract_model_id_from_core_file("foo.cor");
+
+    ASSERT_EQ(expected_model_id, actual_model_id);
+  }
+
+  // cleanup to remove the dummy .bit and .cor files
+  remove("foo.bit");
+  remove("foo.cor");
+}
+
+}

--- a/gtest/bit2core_test.cpp
+++ b/gtest/bit2core_test.cpp
@@ -98,7 +98,7 @@ TEST_F(Bit2coreTestFixture, ShouldAddModelIdIntoHeader)
 TEST_F(Bit2coreTestFixture, ShouldFailIfFpgaPartDoesNotSuitM65Target)
 {
   generate_dummy_bit_file("foo.bit", "nexys4");
-  int exitcode = call_bit2core_with_args("nexys4", "foo.bit", "foo.cor");
+  int exitcode = call_bit2core_with_args("wukonga100t", "foo.bit", "foo.cor");
   ASSERT_EQ(-4, exitcode);
 }
 

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -165,18 +165,6 @@ TEST(Mega65FtpTest, GetCommandExpectTwoParamGivenOne)
   ASSERT_STREQ("TEST.D81", strSrc);
 }
 
-// TODO: Ponder making use of fixtures one day, if I see a common setup/teardown pattern in several tests
-class Mega65FtpTestFixture : public ::testing::Test {
-  protected:
-  void SetUp() override
-  {
-  }
-
-  void TearDown() override
-  {
-  }
-};
-
 void generate_dummy_file(const char* name, int size)
 {
   FILE* f = fopen(name, "wb");
@@ -191,20 +179,38 @@ void delete_local_file(const char* name)
   remove(name);
 }
 
-TEST(Mega65FtpTest, PutCommandWritesFileToContiguousClusters)
-{
-  // suppress the chatty output
-  ::testing::internal::CaptureStderr();
-  ::testing::internal::CaptureStdout();
+class Mega65FtpTestFixture : public ::testing::Test {
+protected:
+  char* file4kb = "4kbtest.tmp";
+  char* file8kb = "8kbtest.d81";
 
+  void SetUp() override
+  {
+    // suppress the chatty output
+    ::testing::internal::CaptureStderr();
+    ::testing::internal::CaptureStdout();
+
+    generate_dummy_file(file4kb, 4096);
+    generate_dummy_file(file8kb, 8192);
+  }
+
+  void TearDown() override
+  {
+    testing::internal::GetCapturedStderr();
+    testing::internal::GetCapturedStdout();
+
+    // cleanup
+    delete_local_file(file4kb);
+    delete_local_file(file8kb);
+  }
+};
+
+TEST_F(Mega65FtpTestFixture, PutCommandWritesFileToContiguousClusters)
+{
   init_sdcard_data();
 
   // sector = 512 bytes
   // cluster = 8 sectors = 8 x 512 = 4096 bytes (4kb)
-  char* file4kb = "4kbtest.tmp";
-  char* file8kb = "8kbtest.d81";
-  generate_dummy_file(file4kb, 4096);
-  generate_dummy_file(file8kb, 8192);
 
   // upload three 4kb files, consuming the clusters this way:
   //
@@ -233,10 +239,6 @@ TEST(Mega65FtpTest, PutCommandWritesFileToContiguousClusters)
   ASSERT_EQ(0, is_fragmented("4kb1.tmp"));
   ASSERT_EQ(0, is_fragmented("4kb3.tmp"));
   ASSERT_EQ(0, is_fragmented(file8kb));
-
-  // cleanup
-  delete_local_file(file4kb);
-  delete_local_file(file8kb);
 }
 
 } // namespace mega65_ftp

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -180,7 +180,7 @@ void delete_local_file(const char* name)
 }
 
 class Mega65FtpTestFixture : public ::testing::Test {
-protected:
+  protected:
   char* file4kb = "4kbtest.tmp";
   char* file8kb = "8kbtest.d81";
 

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -193,6 +193,10 @@ void delete_local_file(const char* name)
 
 TEST(Mega65FtpTest, PutCommandWritesFileToContiguousClusters)
 {
+  // suppress the chatty output
+  ::testing::internal::CaptureStderr();
+  ::testing::internal::CaptureStdout();
+
   init_sdcard_data();
 
   // sector = 512 bytes

--- a/include/dirtymock.h
+++ b/include/dirtymock.h
@@ -1,0 +1,10 @@
+#ifndef DIRTYMOCK_H
+#define DIRTYMOCK_H
+
+#ifdef TESTING
+#define DIRTYMOCK(fn_name) real_##fn_name
+#else
+#define DIRTYMOCK(fn_name) fn_name
+#endif
+
+#endif // DIRTYMOCK_H

--- a/src/tools/bit2core.c
+++ b/src/tools/bit2core.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <strings.h>
 
+extern const char *version_string;
+
 #define MAX_MB 8
 #define BYTES_IN_MEGABYTE (1024 * 1024)
 #define MAGIC_STR "MEGA65BITSTREAM0"
@@ -77,11 +79,13 @@ void show_mega65_target_name_list(void)
 
 void show_help(void)
 {
-  fprintf(stderr, "MEGA65 bitstream to core file converter v0.0.5.\n"
+  fprintf(stderr, "MEGA65 bitstream to core file converter\n"
                   "---------------------------------------\n"
+                  "Version: %s\n\n" 
                   "Usage: <m65target> <foo.bit> <core name> <core version> <out.cor>\n"
                   "\n"
-                  "Note: 1st argument specifies your Mega65 target name, which can be either:\n\n");
+                  "Note: 1st argument specifies your Mega65 target name, which can be either:\n\n",
+                  version_string);
 
   show_mega65_target_name_list();
 }

--- a/src/tools/bit2core.c
+++ b/src/tools/bit2core.c
@@ -4,7 +4,7 @@
 #include <strings.h>
 #include "dirtymock.h"
 
-extern const char *version_string;
+extern const char* version_string;
 
 #define MAX_MB 8
 #define BYTES_IN_MEGABYTE (1024 * 1024)
@@ -44,7 +44,7 @@ static int m65targetgroup_count = sizeof(m65targetgroups) / sizeof(m65target_inf
 
 typedef struct {
   char name[MAX_M65_TARGET_NAME_LEN];
-  int  model_id;
+  int model_id;
 } m65target_to_model_id;
 
 // clang-format off
@@ -75,11 +75,9 @@ int get_model_id(const char* m65targetname)
 }
 
 #pragma pack(push, 1)
-typedef union
-{
+typedef union {
   char data[CORE_HEADER_SIZE];
-  struct
-  {
+  struct {
     char magic[16];
     char core_name[32];
     char core_version[32];
@@ -88,7 +86,6 @@ typedef union
   };
 } header_info;
 #pragma pack(pop)
-
 
 void split_out_and_print_m65target_names(m65target_info* m65target)
 {
@@ -114,13 +111,14 @@ void show_mega65_target_name_list(void)
 
 void show_help(void)
 {
-  fprintf(stderr, "MEGA65 bitstream to core file converter\n"
-                  "---------------------------------------\n"
-                  "Version: %s\n\n" 
-                  "Usage: <m65target> <foo.bit> <core name> <core version> <out.cor>\n"
-                  "\n"
-                  "Note: 1st argument specifies your Mega65 target name, which can be either:\n\n",
-                  version_string);
+  fprintf(stderr,
+      "MEGA65 bitstream to core file converter\n"
+      "---------------------------------------\n"
+      "Version: %s\n\n"
+      "Usage: <m65target> <foo.bit> <core name> <core version> <out.cor>\n"
+      "\n"
+      "Note: 1st argument specifies your Mega65 target name, which can be either:\n\n",
+      version_string);
 
   show_mega65_target_name_list();
 }
@@ -234,7 +232,8 @@ int check_bitstream_file(m65target_info* m65target, int bit_size)
   return 0;
 }
 
-void write_core_file(const int bit_size, const char* core_name, const char* core_version, const char* m65target_name, const char* core_filename)
+void write_core_file(const int bit_size, const char* core_name, const char* core_version, const char* m65target_name,
+    const char* core_filename)
 {
   FILE* of = fopen(core_filename, "wb");
   if (!of) {
@@ -247,7 +246,7 @@ void write_core_file(const int bit_size, const char* core_name, const char* core
 
   memset(header_block.data, 0, CORE_HEADER_SIZE);
 
-  for(int i = 0; i<16; i++)
+  for (int i = 0; i < 16; i++)
     header_block.magic[i] = MAGIC_STR[i];
 
   strcpy(header_block.core_name, core_name);

--- a/src/tools/bit2core.c
+++ b/src/tools/bit2core.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include "dirtymock.h"
 
 extern const char *version_string;
 
@@ -18,7 +19,7 @@ extern const char *version_string;
 #define ARG_COREPATH argv[5]
 
 #define CORE_HEADER_SIZE 4096
-static const int BITSTREAM_HEADER_FPGA_PART_LOC = 0x4C;
+int BITSTREAM_HEADER_FPGA_PART_LOC = 0x4C;
 
 static unsigned char bitstream_data[MAX_MB * BYTES_IN_MEGABYTE];
 
@@ -29,16 +30,49 @@ typedef struct {
 } m65target_info;
 
 // clang-format off
-static m65target_info m65targets[] = {
-  // Mega65 Target Name             MB  FPGA Part
-  { "nexys4|nexys4ddr|megaphoner1", 4, "7a100tcsg324" },
-  { "mega65r2",                     4, "7a100tfgg484" },
-  { "mega65r3",                     8, "7a200tfbg484" }
+static m65target_info m65targetgroups[] = {
+  // Mega65 Target Name/s                           MB  FPGA Part
+  { "nexys4|nexys4ddr|nexys4ddrwidget|megaphoner1", 4, "7a100tcsg324" },
+  { "mega65r2",                                     4, "7a100tfgg484" },
+  { "mega65r1|mega65r3",                            8, "7a200tfbg484" },
+  { "wukonga100t",                                  4, "7a100tfgg676" }
 };
 // clang-format on
 // NOTE: Append future revision details to end of this array
 
-static int m65target_count = sizeof(m65targets) / sizeof(m65target_info);
+static int m65targetgroup_count = sizeof(m65targetgroups) / sizeof(m65target_info);
+
+typedef struct {
+  char name[MAX_M65_TARGET_NAME_LEN];
+  int  model_id;
+} m65target_to_model_id;
+
+// clang-format off
+static m65target_to_model_id map_m65target_to_model_id[] = {
+  // Mega65 Target Name   // Model ID
+  { "mega65r1",           0x01 },
+  { "mega65r2",           0x02 },
+  { "mega65r3",           0x03 },
+  { "megaphoner1",        0x21 },
+  { "nexys4",             0x40 }, // aka 'nexys4psram'
+  { "nexys4ddr",          0x41 },
+  { "nexys4ddrwidget",    0x42 },
+  { "wukonga100t",        0xFD }
+};
+// clang-format on
+
+static int m65target_to_model_id_count = sizeof(map_m65target_to_model_id) / sizeof(m65target_to_model_id);
+
+int get_model_id(const char* m65targetname)
+{
+  for (int k = 0; k < m65target_to_model_id_count; k++) {
+    if (strcmp(map_m65target_to_model_id[k].name, m65targetname) == 0) {
+      return map_m65target_to_model_id[k].model_id;
+    }
+  }
+  printf("ERROR: Failed to find model id for m65target of '%s'...", m65targetname);
+  exit(1);
+}
 
 #pragma pack(push, 1)
 typedef union
@@ -50,6 +84,7 @@ typedef union
     char core_name[32];
     char core_version[32];
     char m65_target[32];
+    unsigned char model_id;
   };
 } header_info;
 #pragma pack(pop)
@@ -71,9 +106,9 @@ void show_mega65_target_name_list(void)
   fprintf(stderr, "  %-15s %s\n", "m65target", "FPGA part");
   fprintf(stderr, "  %-15s %s\n", "---------", "---------");
 
-  for (int idx = 0; idx < m65target_count; idx++) {
+  for (int idx = 0; idx < m65targetgroup_count; idx++) {
     // split out synonym names based on '|' symbol?
-    split_out_and_print_m65target_names(&m65targets[idx]);
+    split_out_and_print_m65target_names(&m65targetgroups[idx]);
   }
 }
 
@@ -104,11 +139,11 @@ int is_match_on_m65targetname_string(const char* m65target, const char* m65targe
   return 0;
 }
 
-m65target_info* find_m65target_from_m65targetname(const char* m65targetname)
+m65target_info* find_m65targetinfo_from_m65targetname(const char* m65targetname)
 {
-  for (int idx = 0; idx < m65target_count; idx++) {
-    if (is_match_on_m65targetname_string(m65targetname, m65targets[idx].name)) {
-      return &m65targets[idx];
+  for (int idx = 0; idx < m65targetgroup_count; idx++) {
+    if (is_match_on_m65targetname_string(m65targetname, m65targetgroups[idx].name)) {
+      return &m65targetgroups[idx];
     }
   }
 
@@ -121,13 +156,13 @@ m65target_info* find_m65target_from_m65targetname(const char* m65targetname)
   exit(-1);
 }
 
-m65target_info* find_m65target_from_fpga_part(char* fpga_part)
+m65target_info* find_m65targetinfo_from_fpga_part(char* fpga_part)
 {
-  for (int idx = 0; idx < m65target_count; idx++) {
-    if (strcmp(fpga_part, m65targets[idx].fpga_part) == 0) {
+  for (int idx = 0; idx < m65targetgroup_count; idx++) {
+    if (strcmp(fpga_part, m65targetgroups[idx].fpga_part) == 0) {
       printf("This bitstream's FPGA part is suitable for the following mega65 targets: \"%s\" (FPGA part: %s)\n",
-          m65targets[idx].name, m65targets[idx].fpga_part);
-      return &m65targets[idx];
+          m65targetgroups[idx].name, m65targetgroups[idx].fpga_part);
+      return &m65targetgroups[idx];
     }
   }
 
@@ -148,7 +183,7 @@ int check_bitstream_header_has_suitable_fpga_part_for_m65target(m65target_info* 
 {
   char* fpga_part = (char*)&bitstream[BITSTREAM_HEADER_FPGA_PART_LOC];
 
-  m65target_info* discovered_m65target = find_m65target_from_fpga_part(fpga_part);
+  m65target_info* discovered_m65target = find_m65targetinfo_from_fpga_part(fpga_part);
 
   if (discovered_m65target == NULL)
     return 0;
@@ -218,6 +253,7 @@ void write_core_file(const int bit_size, const char* core_name, const char* core
   strcpy(header_block.core_name, core_name);
   strcpy(header_block.core_version, core_version);
   strcpy(header_block.m65_target, m65target_name);
+  header_block.model_id = get_model_id(m65target_name);
 
   fwrite(header_block.data, CORE_HEADER_SIZE, 1, of);
   fwrite(bitstream_data, bit_size, 1, of);
@@ -226,7 +262,13 @@ void write_core_file(const int bit_size, const char* core_name, const char* core
   fprintf(stderr, "Core file written: \"%s\"\n", core_filename);
 }
 
-int main(int argc, char** argv)
+char* find_fpga_part_from_m65targetname(const char* m65targetname)
+{
+  m65target_info* m65target = find_m65targetinfo_from_m65targetname(m65targetname);
+  return m65target->fpga_part;
+}
+
+int DIRTYMOCK(main)(int argc, char** argv)
 {
   int err;
 
@@ -235,7 +277,7 @@ int main(int argc, char** argv)
     exit(-1);
   }
 
-  m65target_info* m65target = find_m65target_from_m65targetname(ARG_M65TARGETNAME);
+  m65target_info* m65target = find_m65targetinfo_from_m65targetname(ARG_M65TARGETNAME);
 
   int bit_size = read_bitstream_file(ARG_BITSTREAMPATH);
 

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -43,12 +43,7 @@
 #include <stdio.h>
 
 #include "m65common.h"
-
-#ifdef TESTING
-#define DIRTYMOCK(fn_name) real_##fn_name
-#else
-#define DIRTYMOCK(fn_name) fn_name
-#endif
+#include "dirtymock.h"
 
 #define BOOL int
 #define TRUE 1


### PR DESCRIPTION
PR for work done on #19 for BIT2CORE, to add 'm65target' field into the generated .cor file