### PR TITLE
35 compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ script:
 - sudo add-apt-repository "deb http://gurce.net/ubuntu/ bionic main"
 - sudo apt-get update
 - sudo apt install -y libpng-mingw-w64 libusb-1.0-0-mingw-w64
-- make
+- sudo apt-get install -y cc65
+- make USE_LOCAL_CC65=1
 before_deploy:
 - |
   if [[ -z "$TRAVIS_TAG" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifdef USE_LOCAL_CC65
 	CC65_PREFIX=
 else
 	# use the binary built from the submodule
-	CC65_PREFIX=$(PWD)/cc65/bin
+	CC65_PREFIX=$(PWD)/cc65/bin/
 endif
 
 CC65=  $(CC65_PREFIX)cc65

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@
 #CC=	clang
 COPT=	-Wall -g -std=gnu99 -I/opt/local/include -L/opt/local/lib -I/usr/local/include/libusb-1.0 -L/usr/local/lib -mno-sse3 -march=x86-64
 # -I/usr/local/Cellar/libusb/1.0.23/include/libusb-1.0/ -L/usr/local/Cellar/libusb/1.0.23/lib/libusb-1.0/
-CC=	gcc
+CC=	gcc-8
 WINCC=	x86_64-w64-mingw32-gcc
 WINCOPT=	$(COPT) -DWINDOWS -Imingw64/include -Lmingw64/lib
 
 OPHIS=	Ophis/bin/ophis
-OPHISOPT=	-4
+OPHISOPT=	-4 --no-warn
 OPHIS_MON= Ophis/bin/ophis -c
 
 JAVA = java

--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,17 @@ ACME=	/usr/local/bin/acme
 
 ifdef USE_LOCAL_CC65
 	# use locally installed binary (requires 'cc65,ld65,etc' to be in the $PATH)
-	CC65=  cc65
-	CA65=  ca65 --cpu 4510
-	LD65=  ld65 -t none
-	CL65=  cl65 --config src/tests/vicii.cfg
-	CC65_DEPEND=
+	CC65_PREFIX=
 else
 	# use the binary built from the submodule
-	CC65=  cc65/bin/cc65
-	CA65=  cc65/bin/ca65 --cpu 4510
-	LD65=  cc65/bin/ld65 -t none
-	CL65=  cc65/bin/cl65 --config src/tests/vicii.cfg
-	CC65_DEPEND=$(CC65)
+	CC65_PREFIX=$(PWD)/cc65/bin
 endif
+
+CC65=  $(CC65_PREFIX)cc65
+CA65=  $(CC65_PREFIX)ca65 --cpu 4510
+LD65=  $(CC65_PREFIX)ld65 -t none
+CL65=  $(CC65_PREFIX)cl65 --config src/tests/vicii.cfg
+CC65_DEPEND=
 
 CBMCONVERT=	cbmconvert/cbmconvert
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #CC=	clang
 COPT=	-Wall -g -std=gnu99 -I/opt/local/include -L/opt/local/lib -I/usr/local/include/libusb-1.0 -L/usr/local/lib -mno-sse3 -march=x86-64
 # -I/usr/local/Cellar/libusb/1.0.23/include/libusb-1.0/ -L/usr/local/Cellar/libusb/1.0.23/lib/libusb-1.0/
-CC=	gcc-8
+CC=	gcc
 WINCC=	x86_64-w64-mingw32-gcc
 WINCOPT=	$(COPT) -DWINDOWS -Imingw64/include -Lmingw64/lib
 

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,21 @@ VIVADO=	./vivado_wrapper
 
 ACME=	/usr/local/bin/acme
 
-CC65=  cc65/bin/cc65
-CA65=  cc65/bin/ca65 --cpu 4510
-LD65=  cc65/bin/ld65 -t none
-CL65=  cc65/bin/cl65 --config src/tests/vicii.cfg
-GHDL=  ghdl/build/bin/ghdl
+ifdef USE_LOCAL_CC65
+	# use locally installed binary (requires 'cc65,ld65,etc' to be in the $PATH)
+	CC65=  cc65
+	CA65=  ca65 --cpu 4510
+	LD65=  ld65 -t none
+	CL65=  cl65 --config src/tests/vicii.cfg
+	CC65_DEPEND=
+else
+	# use the binary built from the submodule
+	CC65=  cc65/bin/cc65
+	CA65=  cc65/bin/ca65 --cpu 4510
+	LD65=  cc65/bin/ld65 -t none
+	CL65=  cc65/bin/cl65 --config src/tests/vicii.cfg
+	CC65_DEPEND=$(CC65)
+endif
 
 CBMCONVERT=	cbmconvert/cbmconvert
 
@@ -88,14 +98,14 @@ $(SDCARD_DIR)/FREEZER.M65:
 $(CBMCONVERT):
 	git submodule init
 	git submodule update
-	echo "Saving 'cbmconvert' build output to 'cbmconvert_build_log.txt'..."
-	( cd cbmconvert && make -f Makefile.unix &> cbmconvert_build_log.txt )
+	( cd cbmconvert && make -f Makefile.unix )
 
+ifndef USE_LOCAL_CC65
 $(CC65):
 	git submodule init
 	git submodule update
-	echo "Saving 'cc65' build output to 'cc65_build_log.txt'..."
-	( cd cc65 && make -j 8 &> cc65_build_log.txt )
+	( cd cc65 && make -j 8 )
+endif
 
 $(OPHIS):
 	git submodule init

--- a/Makefile
+++ b/Makefile
@@ -88,12 +88,14 @@ $(SDCARD_DIR)/FREEZER.M65:
 $(CBMCONVERT):
 	git submodule init
 	git submodule update
-	( cd cbmconvert && make -f Makefile.unix )
+	echo "Saving 'cbmconvert' build output to 'cbmconvert_build_log.txt'..."
+	( cd cbmconvert && make -f Makefile.unix &> cbmconvert_build_log.txt )
 
 $(CC65):
 	git submodule init
 	git submodule update
-	( cd cc65 && make -j 8 )
+	echo "Saving 'cc65' build output to 'cc65_build_log.txt'..."
+	( cd cc65 && make -j 8 &> cc65_build_log.txt )
 
 $(OPHIS):
 	git submodule init

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ $(BINDIR)/m65.osx:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c 
 
 
 $(BINDIR)/m65.exe:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/*.c $(TOOLDIR)/fpgajtag/*.h Makefile
-	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/m65.exe $(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/fpgajtag.c $(TOOLDIR)/fpgajtag/util.c $(TOOLDIR)/fpgajtag/process.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lpng -lz -Wl,-Bdynamic
+	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/m65.exe $(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/fpgajtag.c $(TOOLDIR)/fpgajtag/util.c $(TOOLDIR)/fpgajtag/process.c -Wl,-Bstatic -lusb-1.0 -lwsock32 -lws2_32 -lpng -lz -Wl,-Bdynamic
 # $(TOOLDIR)/fpgajtag/listComPorts.c $(TOOLDIR)/fpgajtag/disphelper.c
 
 $(LIBEXECDIR)/ftphelper.bin:	$(TOOLDIR)/ftphelper.a65

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ COPT=	-Wall -g -std=gnu99 -I/opt/local/include -L/opt/local/lib -I/usr/local/inc
 # -I/usr/local/Cellar/libusb/1.0.23/include/libusb-1.0/ -L/usr/local/Cellar/libusb/1.0.23/lib/libusb-1.0/
 CC=	gcc
 WINCC=	x86_64-w64-mingw32-gcc
-WINCOPT=	$(COPT) -DWINDOWS -Imingw64/include -Lmingw64/lib
+WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1
 
 OPHIS=	Ophis/bin/ophis
 OPHISOPT=	-4 --no-warn

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ $(BINDIR)/m65.osx:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c 
 
 
 $(BINDIR)/m65.exe:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/*.c $(TOOLDIR)/fpgajtag/*.h Makefile
-	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/m65.exe $(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/fpgajtag.c $(TOOLDIR)/fpgajtag/util.c $(TOOLDIR)/fpgajtag/process.c -lusb-1.0 -Wl,-Bstatic -lpng -lz -Wl,-Bdynamic
+	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/m65.exe $(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/fpgajtag.c $(TOOLDIR)/fpgajtag/util.c $(TOOLDIR)/fpgajtag/process.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lpng -lz -Wl,-Bdynamic
 # $(TOOLDIR)/fpgajtag/listComPorts.c $(TOOLDIR)/fpgajtag/disphelper.c
 
 $(LIBEXECDIR)/ftphelper.bin:	$(TOOLDIR)/ftphelper.a65

--- a/Makefile
+++ b/Makefile
@@ -130,36 +130,36 @@ $(TOOLDIR)/frame2png:	$(TOOLDIR)/frame2png.c
 
 # verbose, for 1581 format, overwrite
 $(SDCARD_DIR)/M65UTILS.D81:	$(UTILITIES) $(CBMCONVERT)
-	$(warning =============================================================)
-	$(warning ~~~~~~~~~~~~~~~~> Making: $(SDCARD_DIR)/MEGA65.D81)
+	$(info =============================================================)
+	$(info ~~~~~~~~~~~~~~~~> Making: $(SDCARD_DIR)/MEGA65.D81)
 	mkdir -p $(SDCARD_DIR)
 	$(CBMCONVERT) -v2 -D8o $(SDCARD_DIR)/M65UTILS.D81 $(UTILITIES)
 
 # verbose, for 1581 format, overwrite
 $(SDCARD_DIR)/M65TESTS.D81:	$(TESTS) $(CBMCONVERT)
-	$(warning =============================================================)
-	$(warning ~~~~~~~~~~~~~~~~> Making: $(SDCARD_DIR)/MEGA65.D81)
+	$(info =============================================================)
+	$(info ~~~~~~~~~~~~~~~~> Making: $(SDCARD_DIR)/MEGA65.D81)
 	mkdir -p $(SDCARD_DIR)
 	$(CBMCONVERT) -v2 -D8o $(SDCARD_DIR)/M65TESTS.D81 $(TESTS)
 
 # ============================ done moved, print-warn, clean-target
 # ophis converts the *.a65 file (assembly text) to *.prg (assembly bytes)
 %.prg:	%.a65 $(OPHIS)
-	$(warning =============================================================)
-	$(warning ~~~~~~~~~~~~~~~~> Making: $@)
+	$(info =============================================================)
+	$(info ~~~~~~~~~~~~~~~~> Making: $@)
 	$(OPHIS) $(OPHISOPT) $< -l $*.list -m $*.map -o $*.prg
 
 bin65/ethertest.prg:	$(UTILDIR)/ethertest.a65 $(OPHIS)
 	$(OPHIS) $(OPHISOPT) $< -l $*.list -m $*.map -o $*.prg
 
 %.prg:	utilities/%.a65 $(OPHIS)
-	$(warning =============================================================)
-	$(warning ~~~~~~~~~~~~~~~~> Making: $@)
+	$(info =============================================================)
+	$(info ~~~~~~~~~~~~~~~~> Making: $@)
 	$(OPHIS) $(OPHISOPT) utilities/$< -l $*.list -m $*.map -o $*.prg
 
 %.bin:	%.a65 $(OPHIS)
-	$(warning =============================================================)
-	$(warning ~~~~~~~~~~~~~~~~> Making: $@)
+	$(info =============================================================)
+	$(info ~~~~~~~~~~~~~~~~> Making: $@)
 	$(OPHIS) $(OPHISOPT) $< -l $*.list -m $*.map -o $*.prg
 
 %.o:	%.s $(CC65)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Tools and Utilities for the MEGA65 Retro Computers, such as:
 To build on e.g. Debian Linux, install the following packages:
 
 ```
-apt-get install git build-essential libusb-dev install libpng-dev libusb-1.0-0-dev libreadline-dev libgif-dev
+sudo apt-get install git build-essential libusb-dev install libpng-dev libusb-1.0-0-dev libreadline-dev libgif-dev
 ```
 
 If you want to cross-build the tools for Windows, you'll also need:
 
 ```
-apt-get install binutils-mingw-w64 mingw-w64-common gcc-mingw-w64 libz-mingw-w64-dev
+sudo apt-get install binutils-mingw-w64 mingw-w64-common gcc-mingw-w64 libz-mingw-w64-dev
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F192CFC5C989ADAE
 sudo add-apt-repository "deb http://gurce.net/ubuntu/ bionic main"
 sudo apt-get update
@@ -30,10 +30,22 @@ After cloning the repository, enter its directory and call
 make
 ```
 
-For developers that want to commit code to the repo, it's suggested you also install clang, in order to run clang-format.
+For developers that want to commit code to the repo, it's suggested you also install clang-format version 11.
 
 ```
-apt-get install clang
+sudo apt-get install clang-format-11
+sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 10
+sudo update-alternatives --config clang-format
+```
+
+If your official Ubuntu apt repositories only contain older versions, you can download a statically-linked version of v11 from either:
+
+- https://github.com/eozer/clang-tools-static-binaries/releases/download/master-369f669d/clang-format-11_linux-amd64
+- https://github.com/gurcei/clang-tools-static-binaries/releases/download/untagged-3be9747e6ae6df232d87/clang-format-11_linux-amd64
+
+Then do:
+```
+sudo update-alternatives --install /usr/bin/clang-format clang-format /path/to/downloaded/clang-format-11_linux-amd64 20
 ```
 
 You can then apply the enforced style by typing:
@@ -73,11 +85,16 @@ If you want to build specific tools, you can run targets like:
 - `make bin/mega65_ftp.exe`
 - `make bin/m65.exe`
 
-For developers that want to commit code to the repo, it's suggested you also install clang, in order to run clang-format.
+For developers that want to commit code to the repo, it's suggested you also install clang, in order to run clang-format (it presently provides clang-format v11).
 
 ```
 pacman -S clang
 ```
+
+If you prefer to use a statically-linked binary instead, you can download it from either:
+
+- https://github.com/eozer/clang-tools-static-binaries/releases/download/master-369f669d/clang-format-11_windows-amd64.exe
+- https://github.com/gurcei/clang-tools-static-binaries/releases/download/untagged-3cdbf8ef732ddf71ebdf/clang-format-11_windows-amd64.exe
 
 You can then apply the enforced style by typing:
 
@@ -110,3 +127,17 @@ Still a bit in flux at this stage, but there are a few individual make targets a
 
 Other tools within the suite may or may not compile with their equivalent linux targets, haven't confirmed at this stage...
 
+For developers that want to commit code to thie repo, it's suggested that you install clang-format-11.
+
+Perhaps homebrew offers an install of this (haven't checked).
+
+Alternately, you can download statically-linked binaries from either:
+
+- https://github.com/eozer/clang-tools-static-binaries/releases/download/master-369f669d/clang-format-11_macosx-amd64
+- https://github.com/gurcei/clang-tools-static-binaries/releases/download/untagged-22ae84d665118b63c4b1/clang-format-11_macosx-amd64
+
+You can then apply the enforced style by typing:
+
+```
+make format
+```

--- a/src/tests/test_335.c
+++ b/src/tests/test_335.c
@@ -424,7 +424,7 @@ unsigned char led[12];
 
 void main(void)
 {
-  unsigned char playing = 0, x, y;
+  unsigned char playing = 0;
 
   asm("sei");
 

--- a/src/tests/vicii.c
+++ b/src/tests/vicii.c
@@ -536,7 +536,7 @@ void d018_timing_tests(void)
   ok();
 }
 
-int main(int argc, char** argv)
+int main(void)
 {
 
   printf("%c%c"
@@ -580,4 +580,5 @@ int main(int argc, char** argv)
   printf("Testing complete.\n");
   while (1)
     continue;
+  return 0;
 }

--- a/src/tools/fpgajtag/boundary_scan.c
+++ b/src/tools/fpgajtag/boundary_scan.c
@@ -336,18 +336,10 @@ int xilinx_boundaryscan(char* xdc, char* bsdl, char* sensitivity)
 
               if (!count_shown) {
                 if (vcd) {
-#ifdef WINDOWS
-                  fprintf(vcd, "#%I64d\n", time_delta);
-#else
                   fprintf(vcd, "#%lld\n", time_delta);
-#endif
                 }
                 else {
-#ifdef WINDOWS
-                  printf("T+%I64dusec >>> Signal(s) changed.\n", time_delta);
-#else
                   printf("T+%lldusec >>> Signal(s) changed.\n", time_delta);
-#endif
                 }
               }
               count_shown++;

--- a/src/tools/fpgajtag/fpgajtag.c
+++ b/src/tools/fpgajtag/fpgajtag.c
@@ -43,25 +43,12 @@
 
 #include "m65common.h"
 
-#ifdef WINDOWS
+#ifdef WINDOWS 
 #include <winsock.h>
-
-u_long htonl(u_long x)
-{
-#if BYTE_ORDER == BIG_ENDIAN
-  return x;
-#elif BYTE_ORDER == LITTLE_ENDIAN
-  return __bswap_32(x);
-#else
-#error "What kind of system is this?"
-#endif
-}
-
-#define ntohl htonl
 #else
 #include <arpa/inet.h>
-#include <libusb.h>
 #endif
+#include <libusb.h>
 #include "util.h"
 #include "fpga.h"
 

--- a/src/tools/fpgajtag/fpgajtag.c
+++ b/src/tools/fpgajtag/fpgajtag.c
@@ -43,7 +43,7 @@
 
 #include "m65common.h"
 
-#ifdef WINDOWS 
+#ifdef WINDOWS
 #include <winsock.h>
 #else
 #include <arpa/inet.h>

--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -298,11 +298,7 @@ int virtual_f011_write(int device, int track, int sector, int side)
     vf011_first_read_time = start - 1;
 
 #if 1
-#ifdef WINDOWS
-  fprintf(stderr, "T+%I64d ms : Servicing hypervisor request for F011 FDC sector write.\n", gettime_ms() - start);
-#else
   fprintf(stderr, "T+%lld ms : Servicing hypervisor request for F011 FDC sector write.\n", gettime_ms() - start);
-#endif
 #endif
 
   if (fd81 == NULL) {

--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -1551,7 +1551,7 @@ int main(int argc, char** argv)
       slow_write(fd, cmd, strlen(cmd));
       slow_write(fd, cmd, strlen(cmd));
       slow_write(fd, cmd, strlen(cmd));
-      sprintf(cmd, 1024, "gfce2\r");
+      snprintf(cmd, 1024, "gfce2\r");
       slow_write(fd, cmd, strlen(cmd));
       start_cpu();
       usleep(50000);

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -22,6 +22,10 @@
 
 #define _GNU_SOURCE
 
+#ifdef WINDOWS
+#define __USE_MINGW_ANSI_STDIO 1
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -22,10 +22,6 @@
 
 #define _GNU_SOURCE
 
-#ifdef WINDOWS
-#define __USE_MINGW_ANSI_STDIO 1
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -119,11 +119,7 @@ void timestamp_msg(char* msg)
 {
   if (!start_time)
     start_time = time(0);
-#ifdef WINDOWS
-  fprintf(stderr, "[T+%I64dsec] %s", (long long)time(0) - start_time, msg);
-#else
   fprintf(stderr, "[T+%lldsec] %s", (long long)time(0) - start_time, msg);
-#endif
 
   return;
 }

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -22,6 +22,10 @@
 
 #define _GNU_SOURCE
 
+#ifdef WINDOWS
+#define __USE_MINGW_ANSI_STDIO 1
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -460,12 +460,17 @@ int main(int argc, char** argv)
 #else
     char* cmd = NULL;
     using_history();
-    snprintf(prompt, 1024, "MEGA65 SD-Card:%s> ", current_dir);
+    int ret = snprintf(prompt, 1024, "MEGA65 SD-Card:%s> ", current_dir);
+    if (ret < 0)
+      ; // suppressing gcc-8 -Wformat-truncation warning like this for now...
+
     while ((cmd = readline(prompt)) != NULL) {
       execute_command(cmd);
       add_history(cmd);
       free(cmd);
-      snprintf(prompt, 1024, "MEGA65 SD-Card:%s> ", current_dir);
+      ret = snprintf(prompt, 1024, "MEGA65 SD-Card:%s> ", current_dir);
+      if (ret < 0)
+        ; // suppressing gcc-8 -Wformat-truncation warning like this for now...
     }
 #endif
   }

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -398,11 +398,7 @@ int main(int argc, char** argv)
     snprintf(cmd, 1024, "fpgajtag -a %s", bitstream);
     fprintf(stderr, "%s\n", cmd);
     system(cmd);
-#ifdef WINDOWS
-    fprintf(stderr, "[T+%I64dsec] Bitstream loaded\n", (long long)time(0) - start_time);
-#else
     fprintf(stderr, "[T+%lldsec] Bitstream loaded\n", (long long)time(0) - start_time);
-#endif
   }
 
   // We used to push the interface to 4mbit to speed things up, but that's not needed now.
@@ -562,7 +558,7 @@ int load_helper(void)
       buffer[8192] = 0;
       if (bytes >= (int)strlen("MEGA65FT1.0"))
         for (int i = 0; i < bytes - strlen("MEGA65FT1.0"); i++) {
-          printf("i=%d, bytes=%d, strlen=%d\n", i, bytes, strlen("MEGA65FT1.0"));
+          printf("i=%d, bytes=%d, strlen=%d\n", i, bytes, (int)strlen("MEGA65FT1.0"));
           if (!strncmp("MEGA65FT1.0", &buffer[i], strlen("MEGA65FT1.0"))) {
             printf("Helper already running. Nothing to do.\n");
             return 0;
@@ -699,13 +695,8 @@ void job_process_results(void)
         // fprintf(stderr,"i=%d, b=%d, recent[30-10]='%s'\n",i,b,&recent[30-10]);
         if (!strncmp((char*)&recent[30 - 10], "FTBATCHDONE", 11)) {
           long long endtime = gettime_us();
-#ifdef WINDOWS
-          if (debug_rx)
-            printf("%I64d: Saw end of batch job after %I64d usec\n", endtime - start_usec, endtime - now);
-#else
           if (debug_rx)
             printf("%lld: Saw end of batch job after %lld usec\n", endtime - start_usec, endtime - now);
-#endif
           //	  dump_bytes(0,"read data",queue_read_data,queue_read_len);
           return;
         }
@@ -968,8 +959,8 @@ int write_sector(const unsigned int sector_number, unsigned char* buffer)
   int retVal = 0;
   do {
     // With new method, we write the data, then schedule the write to happen with a job
-    char cmd[1024];
 #if 0
+    char cmd[1024];
     // Clear pending input first    
     int b=1;
     while(b>0){
@@ -2007,17 +1998,10 @@ int upload_file(char* name, char* dest_name)
       }
       sector_number = partition_start + first_cluster_sector + (sectors_per_cluster * (file_cluster - first_cluster))
                     + sector_in_cluster;
-#ifdef WINDOWS
-      if (0)
-        printf("T+%I64d : Read %d bytes from file, writing to sector $%x (%d) for cluster %d\n", gettime_us() - start_usec,
-            bytes, sector_number, sector_number, file_cluster);
-      printf("\rUploaded %I64d bytes.", (long long)st.st_size - remaining_length);
-#else
       if (0)
         printf("T+%lld : Read %d bytes from file, writing to sector $%x (%d) for cluster %d\n", gettime_us() - start_usec,
             bytes, sector_number, sector_number, file_cluster);
       printf("\rUploaded %lld bytes.", (long long)st.st_size - remaining_length);
-#endif
       fflush(stdout);
 
       if (write_sector(sector_number, buffer)) {
@@ -2050,13 +2034,8 @@ int upload_file(char* name, char* dest_name)
 
     if (time(0) == upload_start)
       upload_start = time(0) - 1;
-#ifdef WINDOWS
-    printf("\rUploaded %I64d bytes in %I64d seconds (%.1fKB/sec)\n", (long long)st.st_size,
-        (long long)time(0) - upload_start, st.st_size * 1.0 / 1024 / (time(0) - upload_start));
-#else
     printf("\rUploaded %lld bytes in %lld seconds (%.1fKB/sec)\n", (long long)st.st_size, (long long)time(0) - upload_start,
         st.st_size * 1.0 / 1024 / (time(0) - upload_start));
-#endif
   } while (0);
 
   return retVal;
@@ -2290,15 +2269,9 @@ int create_dir(char* dest_name)
       int bytes = 512;
       sector_number = partition_start + first_cluster_sector + (sectors_per_cluster * (file_cluster - first_cluster))
                     + sector_in_cluster;
-#ifdef WINDOWS
-      if (0)
-        printf("T+%I64d : Read %d bytes from file, writing to sector $%x (%d) for cluster %d\n", gettime_us() - start_usec,
-            bytes, sector_number, sector_number, file_cluster);
-#else
       if (0)
         printf("T+%lld : Read %d bytes from file, writing to sector $%x (%d) for cluster %d\n", gettime_us() - start_usec,
             bytes, sector_number, sector_number, file_cluster);
-#endif
       fflush(stdout);
 
       if (write_sector(sector_number, buffer)) {
@@ -2331,13 +2304,8 @@ int create_dir(char* dest_name)
 
     if (time(0) == upload_start)
       upload_start = time(0) - 1;
-#ifdef WINDOWS
-    printf("\rUploaded %I64d bytes in %I64d seconds (%.1fKB/sec)\n", (long long)4096, (long long)time(0) - upload_start,
-        4096 * 1.0 / 1024 / (time(0) - upload_start));
-#else
     printf("\rUploaded %lld bytes in %lld seconds (%.1fKB/sec)\n", (long long)4096, (long long)time(0) - upload_start,
         4096 * 1.0 / 1024 / (time(0) - upload_start));
-#endif
   } while (0);
 
   return retVal;
@@ -2499,19 +2467,11 @@ int download_file(char* dest_name, char* local_name, int showClusters)
           fwrite(download_buffer, remaining_bytes, 1, f);
       }
 
-#ifdef WINDOWS
-      if (0)
-        printf("T+%I64d : Read %d bytes from file, writing to sector $%x (%d) for cluster %d\n", gettime_us() - start_usec,
-            (int)de.d_filelen, sector_number, sector_number, file_cluster);
-      if (!showClusters)
-        printf("\rDownloaded %I64d bytes.", (long long)de.d_filelen - remaining_bytes);
-#else
       if (0)
         printf("T+%lld : Read %d bytes from file, writing to sector $%x (%d) for cluster %d\n", gettime_us() - start_usec,
             (int)de.d_filelen, sector_number, sector_number, file_cluster);
       if (!showClusters)
         printf("\rDownloaded %lld bytes.", (long long)de.d_filelen - remaining_bytes);
-#endif
       fflush(stdout);
 
       //      printf("T+%lld : after write.\n",gettime_us()-start_usec);
@@ -2528,13 +2488,8 @@ int download_file(char* dest_name, char* local_name, int showClusters)
     if (time(0) == upload_start)
       upload_start = time(0) - 1;
     if (!showClusters) {
-#ifdef WINDOWS
-      printf("\rDownloaded %I64d bytes in %I64d seconds (%.1fKB/sec)\n", (long long)de.d_filelen,
-          (long long)time(0) - upload_start, de.d_filelen * 1.0 / 1024 / (time(0) - upload_start));
-#else
       printf("\rDownloaded %lld bytes in %lld seconds (%.1fKB/sec)\n", (long long)de.d_filelen,
           (long long)time(0) - upload_start, de.d_filelen * 1.0 / 1024 / (time(0) - upload_start));
-#endif
     }
     else
       printf("\n");

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -22,10 +22,6 @@
 
 #define _GNU_SOURCE
 
-#ifdef WINDOWS
-#define __USE_MINGW_ANSI_STDIO 1
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/utilities/remotesd.c
+++ b/src/utilities/remotesd.c
@@ -404,7 +404,7 @@ void main(void)
               // XXX - Just send it all in one go, since we don't buffer multiple
               // sectors
               if (job_type == 3)
-                rle_write_string(temp_sector_buffer, 0x200);
+                rle_write_string((uint32_t)temp_sector_buffer, 0x200);
               else
                 serial_write_string(temp_sector_buffer, 0x200);
               buffer_ready = 0;


### PR DESCRIPTION
Work done on card #35 to address all compiler warnings in the mega65-tools repo.

Some compiler warnings relating to code within the mega65-libc submodule will be addressed in the https://github.com/MEGA65/mega65-libc/issues/6 sibling card.