### PR TITLE
#45: MEGA65_FTP: Handle double-quoted parameters with spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,14 @@ script:
 - sudo apt-get install -y libgif-dev
 - sudo apt-get install -y libpng-dev
 - sudo apt-get install -y libz-mingw-w64-dev
+- sudo apt-get install -y libgtest-dev
 - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F192CFC5C989ADAE
 - sudo add-apt-repository "deb http://gurce.net/ubuntu/ bionic main"
 - sudo apt-get update
 - sudo apt install -y libpng-mingw-w64 libusb-1.0-0-mingw-w64
 - sudo apt-get install -y cc65
 - make USE_LOCAL_CC65=1
+- make test
 before_deploy:
 - |
   if [[ -z "$TRAVIS_TAG" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
 - sudo apt install -y libpng-mingw-w64 libusb-1.0-0-mingw-w64
 - sudo apt-get install -y cc65
 - make USE_LOCAL_CC65=1
-- make test
+- make USE_LOCAL_CC65=1 test
 before_deploy:
 - |
   if [[ -z "$TRAVIS_TAG" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -455,7 +455,7 @@ $(BINDIR)/vncserver:	$(TOOLDIR)/vncserver.c
 	$(CC) $(COPT) -O3 -o $(BINDIR)/vncserver $(TOOLDIR)/vncserver.c -I/usr/local/include -lvncserver -lpthread
 
 format:
-	find -iname '*.h' -o -iname '*.c' | xargs clang-format --style=file -i
+	find . -type d \( -path ./cc65 -o -path ./cbmconvert \) -prune -false -o -iname '*.h' -o -iname '*.c' -o -iname '*.cpp' | xargs clang-format --style=file -i
 
 clean:
 	rm -f $(SDCARD_FILES) $(TOOLS) $(UTILITIES) $(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,9 @@ $(GTESTBINDIR)/mega65_ftp.test: $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega6
 $(GTESTBINDIR)/mega65_ftp.test.exe: $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
 	$(CXX) $(WINCOPT) -DTESTING -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
 
+test: $(GTESTBINDIR)/mega65_ftp.test.exe
+	$(GTESTBINDIR)/mega65_ftp.test.exe
+
 $(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
 	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 COPT=	-Wall -g -std=gnu99 -I/opt/local/include -L/opt/local/lib -I/usr/local/include/libusb-1.0 -L/usr/local/lib -mno-sse3 -march=x86-64
 # -I/usr/local/Cellar/libusb/1.0.23/include/libusb-1.0/ -L/usr/local/Cellar/libusb/1.0.23/lib/libusb-1.0/
 CC=	gcc
+CXX=g++
 WINCC=	x86_64-w64-mingw32-gcc
 WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1
 
@@ -44,6 +45,8 @@ EXAMPLEDIR=	$(SRCDIR)/examples
 UTILDIR=	$(SRCDIR)/utilities
 TESTDIR=	$(SRCDIR)/tests
 LIBEXECDIR=	libexec
+GTESTDIR=gtest
+GTESTBINDIR=$(GTESTDIR)/bin
 
 SDCARD_DIR=	sdcard-files
 
@@ -403,6 +406,9 @@ $(LIBEXECDIR)/ftphelper.bin:	$(TOOLDIR)/ftphelper.a65
 
 $(TOOLDIR)/ftphelper.c:	$(UTILDIR)/remotesd.prg $(TOOLDIR)/bin2c
 	$(TOOLDIR)/bin2c $(UTILDIR)/remotesd.prg helperroutine $(TOOLDIR)/ftphelper.c
+
+$(GTESTBINDIR)/mega65_ftp.test: $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
+	$(CXX) $(COPT) -DTESTING -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
 
 $(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
 	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ $(UTILDIR)/megaphonenorflash.prg:       $(UTILDIR)/megaphonenorflash.c $(CC65)
 $(UTILDIR)/remotesd.prg:       $(UTILDIR)/remotesd.c $(CC65)
 	git submodule init
 	git submodule update
-	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
+	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --listing $*.list --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(TESTDIR)/floppytest.prg:       $(TESTDIR)/floppytest.c $(CC65)
 	git submodule init

--- a/Makefile
+++ b/Makefile
@@ -469,7 +469,7 @@ format:
 	find . -type d \( -path ./cc65 -o -path ./cbmconvert \) -prune -false -o -iname '*.h' -o -iname '*.c' -o -iname '*.cpp' | xargs clang-format --style=file -i
 
 clean:
-	rm -f $(SDCARD_FILES) $(TOOLS) $(UTILITIES) $(TESTS)
+	rm -f $(SDCARD_FILES) $(TOOLS) $(UTILITIES) $(TESTS) $(UTILDIR)/*.prg
 
 cleangen:	clean
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ TESTDIR=	$(SRCDIR)/tests
 LIBEXECDIR=	libexec
 GTESTDIR=gtest
 GTESTBINDIR=$(GTESTDIR)/bin
+# For now, disable g++ compile warnings on tests (there's so many :))
+GTESTOPTS = -w
 
 SDCARD_DIR=	sdcard-files
 
@@ -408,12 +410,15 @@ $(TOOLDIR)/ftphelper.c:	$(UTILDIR)/remotesd.prg $(TOOLDIR)/bin2c
 	$(TOOLDIR)/bin2c $(UTILDIR)/remotesd.prg helperroutine $(TOOLDIR)/ftphelper.c
 
 $(GTESTBINDIR)/mega65_ftp.test: $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
-	$(CXX) $(COPT) -DTESTING -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
+	$(CXX) $(COPT) $(GTESTOPTS) -DTESTING -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
 
 $(GTESTBINDIR)/mega65_ftp.test.exe: $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
-	$(CXX) $(WINCOPT) -DTESTING -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
+	$(CXX) $(WINCOPT) $(GTESTOPTS) -DTESTING -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
 
-test: $(GTESTBINDIR)/mega65_ftp.test.exe
+test: $(GTESTBINDIR)/mega65_ftp.test
+	$(GTESTBINDIR)/mega65_ftp.test
+
+test.exe: $(GTESTBINDIR)/mega65_ftp.test.exe
 	$(GTESTBINDIR)/mega65_ftp.test.exe
 
 $(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c

--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,9 @@ $(TOOLDIR)/ftphelper.c:	$(UTILDIR)/remotesd.prg $(TOOLDIR)/bin2c
 $(GTESTBINDIR)/mega65_ftp.test: $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
 	$(CXX) $(COPT) -DTESTING -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
 
+$(GTESTBINDIR)/mega65_ftp.test.exe: $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
+	$(CXX) $(WINCOPT) -DTESTING -Iinclude -o $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
+
 $(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
 	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses
 

--- a/README.md
+++ b/README.md
@@ -141,3 +141,26 @@ You can then apply the enforced style by typing:
 ```
 make format
 ```
+
+# Unit tests
+
+Some initial effort is underway to start providing unit tests for our tooling, starting with mega65_ftp.
+
+It presently makes use of gtest release 1.10.0.
+
+Unit tests are housed in the 'gtest/' folder.
+
+The unit test executables are housed in the 'gtest/bin' folder.
+
+E.g. to generate the executable:
+
+```
+make gtest/bin/mega65_ftp.test
+```
+
+To run the unit tests:
+
+```
+cd gtest/bin
+./mega65_ftp.test
+```

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -53,4 +53,13 @@ TEST(Mega65FtpTest, DummyCommandWithStringAndNumeric)
   EXPECT_STREQ("ABC", str);
 }
 
+TEST(Mega65FtpTest, GetCommandExpectTwoParamGivenOne)
+{
+  char strSrc[1024];
+  char strDest[1024];
+  int ret = parse_command("get TEST.D81", "get %s %s", &strSrc, &strDest);
+  ASSERT_EQ(1, ret);
+  ASSERT_STREQ("TEST.D81", strSrc);
+}
+
 } // namespace mega65_ftp

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -1,0 +1,27 @@
+#include "gtest/gtest.h"
+#include <stdarg.h>
+
+int parse_command(const char* str, const char* format, ...);
+
+namespace mega65_ftp {
+
+TEST(Mega65FtpTest, ParseSimplePutCommands) {
+  char src[1024];
+  char dst[1024];
+  int ret = parse_command("put test.d81 TEST.D81", "put %s %s", src, dst);
+  ASSERT_EQ(2, ret);
+  EXPECT_STREQ("test.d81", src);
+  EXPECT_STREQ("TEST.D81", dst);
+}
+
+TEST(Mega65FtpTest, ParsePutCommandWithDoubleQuotedSpaces) { 
+
+  char src[1024];
+  char dst[1024];
+  int ret = parse_command("put \"my test file.d81\" TEST.D81", "put %s %s", src, dst);
+  ASSERT_EQ(2, ret);
+  EXPECT_STREQ("my test file.d81", src);
+  EXPECT_STREQ("TEST.D81", dst);
+}
+
+} // namespace mega65_ftp

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -5,7 +5,8 @@ int parse_command(const char* str, const char* format, ...);
 
 namespace mega65_ftp {
 
-TEST(Mega65FtpTest, ParseSimplePutCommands) {
+TEST(Mega65FtpTest, ParseSimplePutCommands)
+{
   char src[1024];
   char dst[1024];
   int ret = parse_command("put test.d81 TEST.D81", "put %s %s", src, dst);
@@ -14,8 +15,8 @@ TEST(Mega65FtpTest, ParseSimplePutCommands) {
   EXPECT_STREQ("TEST.D81", dst);
 }
 
-TEST(Mega65FtpTest, ParsePutCommandWithDoubleQuotedSpaces) { 
-
+TEST(Mega65FtpTest, ParsePutCommandWithDoubleQuotedSpaces)
+{
   char src[1024];
   char dst[1024];
   int ret = parse_command("put \"my test file.d81\" TEST.D81", "put %s %s", src, dst);

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -25,4 +25,32 @@ TEST(Mega65FtpTest, ParsePutCommandWithDoubleQuotedSpaces)
   EXPECT_STREQ("TEST.D81", dst);
 }
 
+TEST(Mega65FtpTest, ParseSectorCommandWithNumericParam)
+{
+  int num;
+  int ret = parse_command("sector 123", "sector %d", &num);
+  ASSERT_EQ(1, ret);
+  EXPECT_EQ(123, num);
+}
+
+TEST(Mega65FtpTest, DummyCommandWithNumericAndString)
+{
+  int num;
+  char str[1024];
+  int ret = parse_command("test ABC 123", "test %s %d", str, &num);
+  ASSERT_EQ(2, ret);
+  EXPECT_STREQ("ABC", str);
+  EXPECT_EQ(123, num);
+}
+
+TEST(Mega65FtpTest, DummyCommandWithStringAndNumeric)
+{
+  int num;
+  char str[1024];
+  int ret = parse_command("test 123 ABC", "test %d %s", &num, str);
+  ASSERT_EQ(2, ret);
+  EXPECT_EQ(123, num);
+  EXPECT_STREQ("ABC", str);
+}
+
 } // namespace mega65_ftp

--- a/src/tests/m65ftp_test.c
+++ b/src/tests/m65ftp_test.c
@@ -34,7 +34,7 @@ int create_file(int id, int size)
   return 0;
 }
 
-#define MAX_FILE_SIZE (1024 * 1024)
+#define MAX_FILE_SIZE (5 * 1024 * 1024)
 unsigned char buff[MAX_FILE_SIZE];
 
 int verify_file(int id, int size)
@@ -46,7 +46,7 @@ int verify_file(int id, int size)
     exit(-1);
   }
 
-  bzero(buff, MAX_FILE_SIZE);
+  memset(buff, 0, MAX_FILE_SIZE);
   int b = fread(buff, 1, MAX_FILE_SIZE, f);
   if (b != size) {
     fprintf(stderr, "ERROR: File size incorrect: Saw %d, expected %d\n", b, size);
@@ -92,12 +92,15 @@ int main(int argc, char** argv)
   char* ftp = argv[1];
 
   for (int i = 0; i < 256; i++) {
-    int size = random() % MAX_FILE_SIZE;
+    int size = ((rand() % 5) + 1) * 1024 * 1024;
+    printf("===========\n");
+    printf("TEST %d : %dMB\n", i, size / 1024 / 1024);
+    printf("===========\n");
     create_file(i, size);
-    snprintf(cmd, 1024, "%s -D -c 'put %s'", ftp, FILE_NAME);
+    snprintf(cmd, 1024, "%s -c \"put %s\"", ftp, FILE_NAME);
     system(cmd);
     unlink(FILE_NAME);
-    snprintf(cmd, 1024, "%s -D -c 'get %s'", ftp, FILE_NAME);
+    snprintf(cmd, 1024, "%s -c \"get %s\"", ftp, FILE_NAME);
     system(cmd);
     if (verify_file(i, size))
       break;

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -330,7 +330,7 @@ int parse_command(const char* str, const char* format, ...)
   }
 
   va_end(args);
-  return 9;
+  return cnt;
 }
 
 int execute_command(char* cmd)

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -193,12 +193,12 @@ int show_sector(unsigned int sector_num)
   return 0;
 }
 
-int parse_string_param(char** src, char* dest) {
+int parse_string_param(char** src, char* dest)
+{
   int cnt = 0;
   char* srcptr = *src;
   char endchar = ' ';
-  if (*srcptr == '\"')
-  {
+  if (*srcptr == '\"') {
     endchar = '\"';
     srcptr++;
     *src = srcptr;
@@ -221,7 +221,8 @@ int parse_string_param(char** src, char* dest) {
   return 1;
 }
 
-int parse_int_param(char** src, int* dest) {
+int parse_int_param(char** src, int* dest)
+{
   int cnt = 0;
   char str[128];
   char* srcptr = *src;
@@ -257,7 +258,6 @@ int skip_whitespace(char** orig)
 
 int parse_command(const char* str, const char* format, ...)
 {
-  // for now, just pass params to sscanf() 
   va_list args;
   va_start(args, format);
   int ret = vsscanf(str, format, args);
@@ -289,8 +289,7 @@ int parse_command(const char* str, const char* format, ...)
           break;
       }
     }
-    else if (*ptrformat != ' ')
-    {
+    else if (*ptrformat != ' ') {
       if (!skip_whitespace(&ptrstr))
         break;
 

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -230,6 +230,7 @@ int parse_int_param(char** src, int* dest)
   while (*srcptr != ' ' && *srcptr != '\0') {
     if (*srcptr < '0' && *srcptr > '9')
       return 0;
+    srcptr++;
     cnt++;
   }
 

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -834,7 +834,7 @@ void job_process_results(void)
       if (debug_rx)
         dump_bytes(0, "jobresponse", buff, b);
     for (int i = 0; i < b; i++) {
-      // Keep rolling window of most recent chars for interpretting job
+      // Keep rolling window of most recent chars for interpreting job
       // results
       if (data_byte_count) {
         if (q_rle_enable)

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -210,10 +210,13 @@ int parse_string_param(char** src, char* dest)
 
   while (*srcptr != endchar && *srcptr != '\0') {
     if (*srcptr == '\0' && endchar == '\"')
-      return 0;
+      return RET_NOT_FOUND;
     srcptr++;
     cnt++;
   }
+
+  if (cnt == 0)
+    return RET_NOT_FOUND;
 
   strncpy(dest, *src, cnt);
   dest[cnt] = '\0';
@@ -222,7 +225,7 @@ int parse_string_param(char** src, char* dest)
     srcptr++;
 
   *src = srcptr;
-  return 1;
+  return RET_FOUND;
 }
 
 int parse_int_param(char** src, int* dest)
@@ -233,17 +236,20 @@ int parse_int_param(char** src, int* dest)
 
   while (*srcptr != ' ' && *srcptr != '\0') {
     if (*srcptr < '0' && *srcptr > '9')
-      return 0;
+      return RET_NOT_FOUND;
     srcptr++;
     cnt++;
   }
+
+  if (cnt == 0)
+    return RET_NOT_FOUND;
 
   strncpy(str, *src, cnt);
   str[cnt] = '\0';
   *dest = atoi(str);
 
   *src = srcptr;
-  return 1;
+  return RET_FOUND;
 }
 
 int skip_whitespace(char** orig)
@@ -320,10 +326,10 @@ int parse_command(const char* str, const char* format, ...)
   while (*ptrformat != '\0') {
     int ret = parse_format_specifier(&ptrformat, &ptrstr, &args, &cnt);
     if (ret == RET_FAIL)
-      return 0;
+      return cnt;
     else if (ret == RET_NOT_FOUND) {
       if (!parse_non_whitespace(&ptrformat, &ptrstr))
-        return 0;
+        return cnt;
     }
 
     ptrformat++;

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -330,7 +330,7 @@ int parse_command(const char* str, const char* format, ...)
   }
 
   va_end(args);
-  return cnt;
+  return 9;
 }
 
 int execute_command(char* cmd)

--- a/src/tools/pngprepare/md2h65.c
+++ b/src/tools/pngprepare/md2h65.c
@@ -391,7 +391,7 @@ void read_png_file(char* file_name)
 
 int main(int argc, char** argv)
 {
-  int i, x=0, y=0;
+  int i, x = 0, y = 0;
 
   unsigned char text_colour = 1;
   unsigned char indent = 0;

--- a/src/utilities/gmod2-tools.c
+++ b/src/utilities/gmod2-tools.c
@@ -3,68 +3,68 @@
 #include "memory.h"
 
 unsigned short i;
-unsigned char a,b,c;
+unsigned char a, b, c;
 
 int main(void)
 {
   // Fast CPU
-  POKE(0,64);
+  POKE(0, 64);
 
-  POKE(0x286,0x0e);
-  printf("%c\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",0x93);
-  
+  POKE(0x286, 0x0e);
+  printf("%c\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n", 0x93);
+
   // Disable cart first
-  POKE(0xDE00,0x40);
-  
+  POKE(0xDE00, 0x40);
+
   // MEGA65 IO
-  POKE(0xD02F,0x47);
-  POKE(0xD02F,0x53);
+  POKE(0xD02F, 0x47);
+  POKE(0xD02F, 0x53);
 
   // Reset flash to read mode
-  POKE(0xDE00,0xC2);
-  lpoke(0x701F555,0xAA);
-  POKE(0xDE00,0xC1);
-  lpoke(0x701EAAA,0x55);
-  POKE(0xDE00,0xC2);
-  lpoke(0x701F555,0xF0);  
-  
+  POKE(0xDE00, 0xC2);
+  lpoke(0x701F555, 0xAA);
+  POKE(0xDE00, 0xC1);
+  lpoke(0x701EAAA, 0x55);
+  POKE(0xDE00, 0xC2);
+  lpoke(0x701F555, 0xF0);
+
 #if 1
   // Do FLASH identify sequence
-  POKE(0xDE00,0xC2);
-  lpoke(0x701F555,0xAA);
-  POKE(0xDE00,0xC1);
-  lpoke(0x701EAAA,0x55);
-  POKE(0xDE00,0xC2);
-  lpoke(0x701F555,0x90);
+  POKE(0xDE00, 0xC2);
+  lpoke(0x701F555, 0xAA);
+  POKE(0xDE00, 0xC1);
+  lpoke(0x701EAAA, 0x55);
+  POKE(0xDE00, 0xC2);
+  lpoke(0x701F555, 0x90);
 #endif
-  
-  a=lpeek(0x7018000);
-  b=lpeek(0x7018001);
-  c=lpeek(0x7018002);
 
-  lcopy(0x7018000,0x0400,0x100);
-  
-  printf("FLASH identification: %02x %02x %02x\n",a,b,c);
+  a = lpeek(0x7018000);
+  b = lpeek(0x7018001);
+  c = lpeek(0x7018002);
+
+  lcopy(0x7018000, 0x0400, 0x100);
+
+  printf("FLASH identification: %02x %02x %02x\n", a, b, c);
 
   // Allow cart write to finish before we fiddle with $DE00
-  for(i=0;i<256;i++) continue; 
-  
+  for (i = 0; i < 256; i++)
+    continue;
+
   // Read or reset command
-  POKE(0xDE00,0xC0);  
-  lpoke(0x701e000,0xf0);
+  POKE(0xDE00, 0xC0);
+  lpoke(0x701e000, 0xf0);
 
-  POKE(0xDE00,0x00);
-  
-  a=lpeek(0x7018000);
-  b=lpeek(0x7018001);
-  c=lpeek(0x7018002);
+  POKE(0xDE00, 0x00);
 
-  lcopy(0x7018000,0x0400+8*40,0x100);
+  a = lpeek(0x7018000);
+  b = lpeek(0x7018001);
+  c = lpeek(0x7018002);
 
-  printf("First bytes of cart: %02x %02x %02x\n",a,b,c);
+  lcopy(0x7018000, 0x0400 + 8 * 40, 0x100);
+
+  printf("First bytes of cart: %02x %02x %02x\n", a, b, c);
 
   // Some how we corrupt $Dxxx sometimes. Is it CC65 not liking the cart appearing at $8xxx?
-  POKE(0xD011,0x1b);
-  POKE(0xD016,0xC8);  
-  
+  POKE(0xD011, 0x1b);
+  POKE(0xD016, 0xC8);
 }


### PR DESCRIPTION
Work done for card #45 to get mega65_ftp to read in double-quoted string parameters that contain spaces.