### PR TITLE
Fixed (hopefully) by synchronize the m65 <-> HYPPO protocol 

### DIFF
--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -57,6 +57,8 @@ extern int pending_vf011_side;
 
 extern int debug_serial;
 
+extern unsigned char recent_bytes[4];
+
 int osk_enable = 0;
 
 int not_already_loaded = 1;
@@ -280,7 +282,9 @@ int virtual_f011_read(int device, int track, int sector, int side)
   }
 
   /* signal done/result */
+  stop_cpu();
   mega65_poke(0xffd3086, side & 0x7f);
+  start_cpu();
 
   timestamp_msg("");
   vf011_bytes_read += 256;
@@ -341,7 +345,9 @@ int virtual_f011_write(int device, int track, int sector, int side)
   }
 
   /* signal done/result */
+  stop_cpu();
   mega65_poke(0xffd3086, side & 0x0f);
+  start_cpu();
 
   timestamp_msg("");
   vf011_bytes_read += 256;
@@ -2170,12 +2176,12 @@ int main(int argc, char** argv)
 
   // XXX - loop for virtualisation, JTAG boundary scanning etc
 
-  unsigned char recent_bytes[4] = { 0, 0, 0, 0 };
 
   if (virtual_f011) {
     fprintf(stderr, "Entering virtualised F011 wait loop...\n");
     while (1) {
       unsigned char buff[8192];
+
       int b = serialport_read(fd, buff, 8192);
       if (b > 0)
         dump_bytes(2, "VF011 wait", buff, b);
@@ -2219,10 +2225,10 @@ int main(int argc, char** argv)
 
 void do_exit(int retval)
 {
-#ifndef WINDOWS  
+#ifndef WINDOWS
   if (thread_count)
   {
-    timestamp_msg("");    
+    timestamp_msg("");
     fprintf(stderr, "Background tasks may be running running. CONTROL+C to stop...\n");
     for (int i = 0; i < thread_count; i++)
       pthread_join(threads[i], NULL);

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -212,6 +212,7 @@ int pending_vf011_device = 0;
 int pending_vf011_track = 0;
 int pending_vf011_sector = 0;
 int pending_vf011_side = 0;
+unsigned char recent_bytes[4] = { 0, 0, 0, 0 };
 
 void check_for_vf011_jobs(unsigned char* read_buff, int b)
 {
@@ -293,6 +294,12 @@ void purge_and_check_for_vf011_jobs(int stopP)
       check_for_vf011_jobs(read_buff, b);
 
       for (int i = 0; i < b; i++) {
+        recent_bytes[0] = recent_bytes[1];
+        recent_bytes[1] = recent_bytes[2];
+        recent_bytes[2] = recent_bytes[3];
+        recent_bytes[3] = read_buff[i];
+      }
+      for (int i = 0; i < b; i++) {
         recent[0] = recent[1];
         recent[1] = recent[2];
         recent[2] = read_buff[i];
@@ -335,6 +342,7 @@ int stop_cpu(void)
   fprintf(stderr, "Stopping CPU\n");
   if (no_rxbuff)
     do_usleep(50000);
+  cpu_stopped = 1;
   slow_write_safe(fd, "t1\r", 3);
   purge_and_check_for_vf011_jobs(1);
   return 0;


### PR DESCRIPTION
I synchronized the m65 <-> HYPPO protocol for virtual f011 read and write, by halting the CPU while operating.

In that I reconized and fixed that stop_cpu acutally didn't stop the CPU because it was sending the t1 command using safe write before marking the CPU stopped which caused the CPU actually to be stopped and restarted.