### PR TITLE
Remove erroneous install argument from apt-get documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tools and Utilities for the MEGA65 Retro Computers, such as:
 To build on e.g. Debian Linux, install the following packages:
 
 ```
-sudo apt-get install git build-essential libusb-dev install libpng-dev libusb-1.0-0-dev libreadline-dev libgif-dev
+sudo apt-get install git build-essential libusb-dev libpng-dev libusb-1.0-0-dev libreadline-dev libgif-dev
 ```
 
 If you want to cross-build the tools for Windows, you'll also need:


### PR DESCRIPTION
Currently the documentation has this command for installing the dependencies:
`sudo apt-get install git build-essential libusb-dev install libpng-dev libusb-1.0-0-dev libreadline-dev libgif-dev`

Due to `install `being an argument, trying to run this (on Ubuntu 18.04) results in the error:
`E: Unable to locate package install`

This PR removes the `install` argument.