### PR TITLE
Add unit test logging and test name capability to m65

### DIFF
--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -1207,36 +1207,69 @@ int check_file_access(char* file, char* purpose)
 
 extern const char* version_string;
 
-char *test_states[16]={
-		       "START",
-		       " SKIP",
-		       " PASS",
-		       " FAIL",
-		       "ERROR",
-		       "C#$05",
-		       "C#$06",
-		       "C#$07",
-		       "C#$08",
-		       "C#$09",
-		       "C#$0A",
-		       "C#$0B",
-		       "C#$0C",
-		       "C#$0D",
-		       "C#$0E",
-		       " DONE"
-};
+char* test_states[16] = { 
+  "START", 
+  " SKIP", 
+  " PASS", 
+  " FAIL", 
+  "ERROR", 
+  "C#$05", 
+  "C#$06", 
+  "C#$07", 
+  "C#$08", 
+  "C#$09", 
+  "C#$0A",
+  "C#$0B", 
+  "C#$0C", 
+  "  LOG",    /* log message */ 
+  " NAME",    /* set current test name */
+  " DONE" 
+  };
 
-void unit_test_log(unsigned char bytes[4],int argc,char **argv)
+char msgbuf[32];
+char testname[32];
+unsigned char inbuf[8192];
+
+void get_msg()
 {
-  int test_issue=bytes[0]+(bytes[1]<<8);
-  int test_sub=bytes[2];
 
-  //  dump_bytes(0,"bytes",bytes,4);
-  
-  fprintf(stderr,"%s: Issue#%d, Test #%d\n",
-	  test_states[bytes[3]-0xf0],test_issue,test_sub);
-  
-  switch(bytes[3]) {
+  char* current;
+  int i;
+
+  current = msgbuf;
+
+  while (1) {
+
+    int b = serialport_read(fd, inbuf, 8192);
+
+    for (i = 0; i < b; ++i) {
+      *current = inbuf[i];
+      if (*current==92) {
+        // ugly workaround: use pound sign as string end marker, because zeroes
+        // sometimes get corrupted when using the serial line...
+        *current = 0;
+        return;
+      }
+      current++;
+    }
+  }
+}
+
+void unit_test_log(unsigned char bytes[4])
+{
+  int test_issue = bytes[0] + (bytes[1] << 8);
+  int test_sub = bytes[2];
+
+  // dump_bytes(0, "bytes", bytes, 4);
+
+  // log test name if we have one
+  if (testname[0]) {
+    fprintf(stderr, "%s - ",testname);
+  }
+
+  fprintf(stderr, "%s (Issue#%d, Test #%d)\n", test_states[bytes[3] - 0xf0], test_issue, test_sub);
+
+  switch (bytes[3]) {
   case 0xf0: // Starting a test
     break;
   case 0xf1: // Skipping a test
@@ -1247,13 +1280,47 @@ void unit_test_log(unsigned char bytes[4],int argc,char **argv)
     break;
   case 0xf4: // Error trying to run test
     break;
+  case 0xfd: // Log message
+    get_msg();
+    fprintf(stderr, "%s\n",msgbuf);
+    break;
+  case 0xfe: // Set name of current test
+    get_msg();
+    strncpy(testname,msgbuf,32);
+    fprintf(stderr, "set test name to %s\n", testname);
+    break;
   case 0xff: // Last test complete
-    fprintf(stderr,">>> Terminating after completion of last test.\n");
+    fprintf(stderr, ">>> Terminating after completion of last test.\n");
     do_exit(0);
     break;
   }
-  
 }
+
+void enterTestMode()
+{
+
+  fprintf(stderr, "Entering unit test mode. Waiting for test results.\n");
+
+  testname[0]=0; // initialize test name with empty string
+
+  while (1) {
+
+    int b = serialport_read(fd, inbuf, 8192);
+
+    for (int i = 0; i < b; i++) {
+      recent_bytes[0] = recent_bytes[1];
+      recent_bytes[1] = recent_bytes[2];
+      recent_bytes[2] = recent_bytes[3];
+      recent_bytes[3] = inbuf[i];
+
+      if (recent_bytes[3] >= 0xf0) {
+        // Unit test start
+        unit_test_log(recent_bytes);
+      }
+    }
+  }
+}
+
 
 int main(int argc, char** argv)
 {
@@ -2271,15 +2338,15 @@ int main(int argc, char** argv)
     }
   }
 
+   if (unit_test_mode) {
+    enterTestMode();
+  }
+
   // XXX - loop for virtualisation, JTAG boundary scanning etc
 
-  unsigned char recent_bytes[4] = { 0, 0, 0, 0 };
-  
-  if (virtual_f011||unit_test_mode) {
-    if (virtual_f011)
-      fprintf(stderr, "Entering virtualised F011 wait loop...\n");
-    if (unit_test_mode)
-      fprintf(stderr, "Entering unit test mode. Waiting for test results.\n");
+  if (virtual_f011) {
+    fprintf(stderr, "Entering virtualised F011 wait loop...\n");
+
     while (1) {
       unsigned char buff[8192];
 
@@ -2291,29 +2358,24 @@ int main(int argc, char** argv)
         recent_bytes[2] = recent_bytes[3];
         recent_bytes[3] = buff[i];
 
-	if (recent_bytes[3] >= 0xf0) {
-	  // Unit test start
-	  unit_test_log(recent_bytes,argc,argv);
-	}
-	
-	if (recent_bytes[3] == '!') {
-	  // Handle request
-	  recent_bytes[3] = 0;
-	  pending_vf011_read = 1;
-	  pending_vf011_device = 0;
-	  pending_vf011_track = recent_bytes[0] & 0x7f;
-	  pending_vf011_sector = recent_bytes[1] & 0x7f;
-	  pending_vf011_side = recent_bytes[2] & 0x0f;
-	}
-	if (recent_bytes[3] == 0x5c) {
-	  // Handle request
-	  recent_bytes[3] = 0;
-	  pending_vf011_write = 1;
-	  pending_vf011_device = 0;
-	  pending_vf011_track = recent_bytes[0] & 0x7f;
-	  pending_vf011_sector = recent_bytes[1] & 0x7f;
-	  pending_vf011_side = recent_bytes[2] & 0x0f;
-	}
+        if (recent_bytes[3] == '!') {
+          // Handle request
+          recent_bytes[3] = 0;
+          pending_vf011_read = 1;
+          pending_vf011_device = 0;
+          pending_vf011_track = recent_bytes[0] & 0x7f;
+          pending_vf011_sector = recent_bytes[1] & 0x7f;
+          pending_vf011_side = recent_bytes[2] & 0x0f;
+        }
+        if (recent_bytes[3] == 0x5c) {
+          // Handle request
+          recent_bytes[3] = 0;
+          pending_vf011_write = 1;
+          pending_vf011_device = 0;
+          pending_vf011_track = recent_bytes[0] & 0x7f;
+          pending_vf011_sector = recent_bytes[1] & 0x7f;
+          pending_vf011_side = recent_bytes[2] & 0x0f;
+        }
       }
       while (pending_vf011_read || pending_vf011_write) {
         if (pending_vf011_read)


### PR DESCRIPTION
Unit tests can now set their reported name, as well as log messages to the host computer's console.
An updated libc is needed to use this from C (see https://github.com/MEGA65/mega65-libc/pull/10)
