### PR TITLE
Unit test enhancements

### DIFF
--- a/src/tests/runTests.sh
+++ b/src/tests/runTests.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# very simple test runner: find all *.prg files in the current directory
+# and run them.
+#
+# todo: 
+# - detect c64 or c65 mode programs
+# - adapt existing tests to make them aware of the test framework (ugh...)
+
+for file in *.prg; do 
+    if [ -f "$file" ]; then 
+        echo "$file" 
+        ../../bin/m65 -Fur4 $file -w ./tests.log
+    fi 
+done

--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -52,7 +52,6 @@
 
 #define UT_RES_TIMEOUT 127
 
-
 extern int pending_vf011_read;
 extern int pending_vf011_write;
 extern int pending_vf011_device;
@@ -93,50 +92,51 @@ void usage(void)
       "<hickup file>] [-R romfile] [-U flashmenufile] [-C charromfile]] [-c COLOURRAM.BIN] [-B breakpoint] [-a] "
       "[-A <xx[-yy]=ppp>] [-o] [-d diskimage.d81] [-j] [-J <XDC,BSDL[,sensitivity list]> [-V <vcd file>]] [[-1] "
       "[<-t|-T> <text>] [-f FPGA serial ID] [filename]] [-H] [-E|-L] [-Z <flash addr>] [-@ file@addr] [-N] [-u]\n");
-  fprintf(stderr, "  -@ - Load a binary file at a specific address.\n");
-  fprintf(stderr, "  -1 - Load as with ,8,1 taking the load address from the program, instead of assuming $0801\n");
-  fprintf(stderr, "  -4 - Switch to C64 mode before exiting.\n");
-  fprintf(stderr, "  -A - Set audio coefficient(s) xx (and optionally to yy) to ppp percent of maximum volume.\n");
-  fprintf(stderr, "  -a - Read and display audio cross-bar mixer status.\n");
-  fprintf(stderr, "  -B - Set a breakpoint on synchronising, and then immediately exit.\n");
-  fprintf(stderr, "  -b - Name of bitstream file to load.\n");
-  fprintf(stderr, "  -C - Character ROM file to preload.\n");
-  fprintf(stderr, "  -c - Colour RAM contents to preload.\n");
-  fprintf(stderr, "  -d - Enable virtual D81 access\n");
-  fprintf(stderr, "  -E - Enable streaming of video via ethernet.\n");
-  fprintf(stderr, "  -F - Force reset on start\n");
-  fprintf(stderr, "  -f - Specify which FPGA to reconfigure when calling fpgajtag\n");
-  fprintf(stderr, "  -H - Halt CPU after loading ROMs.\n");
-  fprintf(stderr, "  -J - Do JTAG boundary scan of attached FPGA, using the provided XDC and BSDL files.\n");
-  fprintf(stderr, "       A sensitivity list can also be provided, to restrict the set of signals monitored.\n");
-  fprintf(stderr, "       This will likely be required when producing VCD files, as they can only log ~80 signals.\n");
-  fprintf(stderr, "  -j   Do JTAG operation(s), and nothing else.\n");
-  fprintf(stderr, "  -K - Use DK backend for libUSB, if available\n");
-  fprintf(stderr, "  -k - Name of hickup file to forcibly use instead of the HYPPO in the bitstream.\n");
-  fprintf(stderr, "       NOTE: You can use bitstream and/or HYPPO from the Jenkins server by using @issue/tag/hardware\n"
-                  "             for the bitstream, and @issue/tag for HYPPO.\n");
-  fprintf(stderr, "  -L - Enable streaming of CPU instruction log via ethernet.\n");
-  fprintf(stderr, "  -l - Name of serial port to use, e.g., /dev/ttyUSB1\n");
-  fprintf(stderr, "  -o - Enable on-screen keyboard\n");
-  fprintf(stderr, "  -N - Disable a running cartridge, and boot to C64 mode.\n");
-  fprintf(stderr, "  -n - Force NTSC video mode\n");
-  fprintf(stderr, "  -p - Force PAL video mode\n");
-  fprintf(stderr, "  -q - Name of bitstream file to load and then directly quit. Use this for cores other than MEGA65.\n");
-  fprintf(stderr, "  -R - ROM file to preload at $20000-$3FFFF.\n");
-  fprintf(stderr, "  -r - Automatically RUN programme after loading.\n");
-  fprintf(stderr, "  -S - Show the text-mode screen\n");
-  fprintf(stderr, "  -s - Speed of serial port in bits per second. This must match what your bitstream uses.\n");
-  fprintf(stderr, "       (Older bitstream use 230400, and newer ones 2000000 or 4000000).\n");
-  fprintf(stderr, "  -T - As above, but also provide carriage return\n");
-  fprintf(stderr, "  -t - Type text via keyboard virtualisation.\n");
-  fprintf(stderr, "  -U - Flash menu file to preload at $50000-$57FFF.\n");
-  fprintf(stderr, "  -u - Enable unit test mode: m65 does not terminate until it receives a response from a unit test.\n");
-  fprintf(stderr, "  -v - The location of the Vivado executable to use for -b on Windows.\n");
-  fprintf(stderr, "  -V - Write JTAG change log to VCD file, instead of to stdout.\n");
-  fprintf(stderr, "  -X - Show a report of current Hypervisor status.\n");
-  fprintf(stderr, "  -Z - Zap (reconfigure) FPGA from specified hex address in flash.\n");
-  fprintf(stderr, "  filename - Load and run this file in C64 mode before exiting.\n");
-  fprintf(stderr, "\n");
+
+  fprintf(stderr, "  -@ - Load a binary file at a specific address.\n"
+                  "  -1 - Load as with ,8,1 taking the load address from the program, instead of assuming $0801\n"
+                  "  -4 - Switch to C64 mode before exiting.\n"
+                  "  -A - Set audio coefficient(s) xx (and optionally to yy) to ppp percent of maximum volume.\n"
+                  "  -a - Read and display audio cross-bar mixer status.\n"
+                  "  -B - Set a breakpoint on synchronising, and then immediately exit.\n"
+                  "  -b - Name of bitstream file to load.\n"
+                  "  -C - Character ROM file to preload.\n"
+                  "  -c - Colour RAM contents to preload.\n"
+                  "  -d - Enable virtual D81 access\n"
+                  "  -E - Enable streaming of video via ethernet.\n"
+                  "  -F - Force reset on start\n"
+                  "  -f - Specify which FPGA to reconfigure when calling fpgajtag\n"
+                  "  -H - Halt CPU after loading ROMs.\n"
+                  "  -J - Do JTAG boundary scan of attached FPGA, using the provided XDC and BSDL files.\n"
+                  "       A sensitivity list can also be provided, to restrict the set of signals monitored.\n"
+                  "       This will likely be required when producing VCD files, as they can only log ~80 signals.\n"
+                  "  -j   Do JTAG operation(s), and nothing else.\n"
+                  "  -K - Use DK backend for libUSB, if available\n"
+                  "  -k - Name of hickup file to forcibly use instead of the HYPPO in the bitstream.\n"
+                  "       NOTE: You can use bitstream and/or HYPPO from the Jenkins server by using @issue/tag/hardware\n"
+                  "             for the bitstream, and @issue/tag for HYPPO.\n"
+                  "  -L - Enable streaming of CPU instruction log via ethernet.\n"
+                  "  -l - Name of serial port to use, e.g., /dev/ttyUSB1\n"
+                  "  -N - Disable a running cartridge, and boot to C64 mode.\n"
+                  "  -n - Force NTSC video mode\n"
+                  "  -o - Enable on-screen keyboard\n"
+                  "  -p - Force PAL video mode\n"
+                  "  -q - Name of bitstream file to load and then directly quit. Use this for cores other than MEGA65.\n"
+                  "  -R - ROM file to preload at $20000-$3FFFF.\n"
+                  "  -r - Automatically RUN programme after loading.\n"
+                  "  -S - Show the text-mode screen\n"
+                  "  -s - Speed of serial port in bits per second. This must match what your bitstream uses.\n"
+                  "       (Older bitstream use 230400, and newer ones 2000000 or 4000000).\n"
+                  "  -T - As above, but also provide carriage return\n"
+                  "  -t - Type text via keyboard virtualisation.\n"
+                  "  -U - Flash menu file to preload at $50000-$57FFF.\n"
+                  "  -u - Enable unit test mode: m65 does not terminate until it receives a response from a unit test.\n"
+                  "  -v - The location of the Vivado executable to use for -b on Windows.\n"
+                  "  -V - Write JTAG change log to VCD file, instead of to stdout.\n"
+                  "  -X - Show a report of current Hypervisor status.\n"
+                  "  -Z - Zap (reconfigure) FPGA from specified hex address in flash.\n"
+                  "  filename - Load and run this file before exiting.\n"
+                  "\n");
   exit(-3);
 }
 

--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -1270,22 +1270,35 @@ void unit_test_log(unsigned char bytes[4])
   int test_issue = bytes[0] + (bytes[1] << 8);
   int test_sub = bytes[2];
   char outstring[255];
+  char temp[255];
+
+  time_t currentTime;
+  char* ts;
 
   // dump_bytes(0, "bytes", bytes, 4);
 
-  // log test name if we have one
+  bzero(outstring, 255);
+
+  currentTime = time(NULL);
+  ts = asctime(localtime(&currentTime));
+  ts[strlen(ts) - 1] = 0;
+  strcat(outstring, ts);
+
+  sprintf(temp, " %s (Issue#%04d, Test #%03d", test_states[bytes[3] - 0xf0], test_issue, test_sub);
+  strcat(outstring, temp);
+
+  // append current test name if we have one
   if (testname[0]) {
-    fprintf(stderr, "%s: ", testname);
-    if (logPtr) {
-      fprintf(logPtr, "%s: ", testname);
-    }
+    sprintf(temp, " - %s)", testname);
   }
+  else {
+    sprintf(temp, ")");
+  }
+  strcat(outstring, temp);
 
-  sprintf(outstring, "%s (Issue#%d, Test #%d)\n", test_states[bytes[3] - 0xf0], test_issue, test_sub);
-
-  fprintf(stderr, "%s", outstring);
+  fprintf(stderr, "%s\n", outstring);
   if (logPtr) {
-    fprintf(logPtr, "%s", outstring);
+    fprintf(logPtr, "%s\n", outstring);
     fflush(logPtr);
   }
 
@@ -1323,7 +1336,7 @@ void enterTestMode()
   unsigned char receiveString;
   int currentMessagePos;
   time_t currentTime;
-  char *ts;
+  char* ts;
 
   fprintf(stderr, "Entering unit test mode. Waiting for test results.\n");
   testname[0] = 0; // initialize test name with empty string
@@ -1342,10 +1355,10 @@ void enterTestMode()
     }
 
     ts = asctime(localtime(&currentTime));
-    ts[strlen(ts)-1] = 0;
+    ts[strlen(ts) - 1] = 0;
 
     fprintf(stderr, "logging test results in %s\n", logfile);
-    fprintf(logPtr, "\n>>> begin testing %s; FILE: %s\n",ts,filename);
+    fprintf(logPtr, "\n>>> begin testing %s; FILE: %s\n", ts, filename);
   }
 
   while (time(NULL) - currentTime < UT_TIMEOUT) {

--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -1337,7 +1337,7 @@ void enterTestMode()
 
     logPtr = fopen(logfile, "a");
     if (!logPtr) {
-      fprintf(stderr, "could not open logfile %s for reading. aborting\n", logfile);
+      fprintf(stderr, "could not open logfile %s for appending. aborting\n", logfile);
       exit(127);
     }
 


### PR DESCRIPTION
- adds timeout for unit test mode
- return value now either 0 for "all tests passed", or number of failed tests
- new option "-w" for writing/appending unit test log files
- adds a (fairly simple and preliminary) test runner script that scans the current directory for *.prg files and launches each of them in m65 unit test mode, writing the aggregate results to "tests.log"