### PR TITLE
Fix #66 - Add libncurses5-dev as a required package to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tools and Utilities for the MEGA65 Retro Computers, such as:
 To build on e.g. Debian Linux, install the following packages:
 
 ```
-sudo apt-get install git build-essential libusb-dev libpng-dev libusb-1.0-0-dev libreadline-dev libgif-dev
+sudo apt-get install git build-essential libusb-dev libpng-dev libusb-1.0-0-dev libreadline-dev libgif-dev libncurses5-dev
 ```
 
 If you want to cross-build the tools for Windows, you'll also need:


### PR DESCRIPTION
This is an edit to `README.md` to include `libncurses5-dev`, as suggested in [#66](https://github.com/MEGA65/mega65-tools/issues/66).  This is required to make `mega65_ftp` on a fresh Ubuntu 18.02 install. 