### PR TITLE
#60: tweaks for xemu (to improve comms over tcp)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,17 +470,17 @@ test.exe: $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTBINDIR)/bit2core.test.exe
 	$(GTESTBINDIR)/mega65_ftp.test.exe
 	$(GTESTBINDIR)/bit2core.test.exe
 
-$(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
-	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lreadline -lncurses
+$(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c
+	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c -lreadline -lncurses
 
-$(BINDIR)/mega65_ftp.static:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a
-	$(CC) $(COPT) -Iinclude -mno-sse3 -o $(BINDIR)/mega65_ftp.static $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a -ltermcap
+$(BINDIR)/mega65_ftp.static:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a
+	$(CC) $(COPT) -Iinclude -mno-sse3 -o $(BINDIR)/mega65_ftp.static $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a -ltermcap
 
-$(BINDIR)/mega65_ftp.exe:	$(TOOLDIR)/mega65_ftp.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/m65common.c
-	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
+$(BINDIR)/mega65_ftp.exe:	$(TOOLDIR)/mega65_ftp.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c
+	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
 
-$(BINDIR)/mega65_ftp.osx:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/ftphelper.c Makefile $(TOOLDIR)/m65common.c
-	$(CC) $(COPT) -D__APPLE__ -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -o $(BINDIR)/mega65_ftp.osx $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c -lusb-1.0 -lz -lpthread -lreadline
+$(BINDIR)/mega65_ftp.osx:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/ftphelper.c Makefile $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c
+	$(CC) $(COPT) -D__APPLE__ -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -o $(BINDIR)/mega65_ftp.osx $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c -lusb-1.0 -lz -lpthread -lreadline
 
 $(BINDIR)/bitinfo:	$(TOOLDIR)/bitinfo.c Makefile 
 	$(CC) $(COPT) -g -Wall -o $(BINDIR)/bitinfo $(TOOLDIR)/bitinfo.c

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ COPT=	-Wall -g -std=gnu99 -I/opt/local/include -L/opt/local/lib -I/usr/local/inc
 CC=	gcc
 CXX=g++
 WINCC=	x86_64-w64-mingw32-gcc
-WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1
+WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1 -Llibusb-1.0.24/build/libusb/.libs/ -L/mingw64/lib
 
 OPHIS=	Ophis/bin/ophis
 OPHISOPT=	-4 --no-warn
@@ -249,7 +249,7 @@ $(UTILDIR)/megaphonenorflash.prg:       $(UTILDIR)/megaphonenorflash.c $(CC65)
 $(UTILDIR)/remotesd.prg:       $(UTILDIR)/remotesd.c $(CC65)
 	git submodule init
 	git submodule update
-	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --listing $*.list --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
+	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --listing $*.list --mapfile $*.map --add-source $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(TESTDIR)/floppytest.prg:       $(TESTDIR)/floppytest.c $(CC65)
 	git submodule init

--- a/Makefile
+++ b/Makefile
@@ -455,7 +455,7 @@ endef
 # Gives two targets of:
 # - gtest/bin/mega65_ftp.test
 # - gtest/bin/mega65_ftp.test.exe
-$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/mega65_ftp.test, $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c Makefile))
+$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/mega65_ftp.test, $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c Makefile))
 
 # Gives two targets of:
 # - gtest/bin/bit2core.test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ COPT=	-Wall -g -std=gnu99 -I/opt/local/include -L/opt/local/lib -I/usr/local/inc
 CC=	gcc
 CXX=g++
 WINCC=	x86_64-w64-mingw32-gcc
-WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1 -Llibusb-1.0.24/build/libusb/.libs/ -L/mingw64/lib
+WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1
 
 OPHIS=	Ophis/bin/ophis
 OPHISOPT=	-4 --no-warn

--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -1439,7 +1439,7 @@ int main(int argc, char** argv)
 
   fprintf(stderr,
       "MEGA65 Cross-Platform tool.\n"
-      "version: %s\n",
+      "version: %s\n\n",
       version_string);
 
   timestamp_msg("");

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -138,8 +138,8 @@ int do_slow_write(PORT_TYPE fd, char* d, int l, const char* func, const char* fi
 {
   // NOTE: if we're connecting to xemu, slow down the speed of commands sent to
   // its uart monitor, as it can't handle too many of them in quick succession
-  //if (xemu_flag)
-  //  usleep(500000);
+  // if (xemu_flag)
+  //   usleep(500000);
 
   // UART is at 2Mbps, but we need to allow enough time for a whole line of
   // writing. 100 chars x 0.5usec = 500usec. So 1ms between chars should be ok.
@@ -175,8 +175,8 @@ int do_slow_write(PORT_TYPE fd, char* d, int l, const char* func, const char* fi
   }
   // NOTE: if we're connecting to xemu, slow down the speed of commands sent to
   // its uart monitor, as it can't handle too many of them in quick succession
-  //if (xemu_flag)
-  //  usleep(500000);
+  // if (xemu_flag)
+  //   usleep(500000);
   return 0;
 }
 
@@ -862,8 +862,8 @@ int push_ram(unsigned long address, unsigned int count, unsigned char* buffer)
 
     // for xemu_flag, try add a pause between successive 'l' commands
     // to see if it helps with stalling issues
-    //if (xemu_flag)
-    //  do_usleep(5000 * SLOW_FACTOR);
+    // if (xemu_flag)
+    //   do_usleep(5000 * SLOW_FACTOR);
 
     wait_for_prompt();
     offset += b;
@@ -905,8 +905,8 @@ int fetch_ram(unsigned long address, unsigned int count, unsigned char* buffer)
       int b = serialport_read(fd, &read_buff[ofs], 8192 - ofs);
       if (b <= 0)
         b = 0;
-      //else
-      //  printf("%s\n", read_buff);
+      // else
+      //   printf("%s\n", read_buff);
       if ((ofs + b) > 8191)
         b = 8191 - ofs;
       //      if (b) dump_bytes(0,"read data",&read_buff[ofs],b);
@@ -1154,12 +1154,14 @@ void print_error(const char* context)
 HANDLE open_serial_port(const char* device, uint32_t baud_rate)
 {
   // COM10+ need to have \\.\ added to the front
-  // (see https://support.microsoft.com/en-us/topic/howto-specify-serial-ports-larger-than-com9-db9078a5-b7b6-bf00-240f-f749ebfd913e
+  // (see
+  // https://support.microsoft.com/en-us/topic/howto-specify-serial-ports-larger-than-com9-db9078a5-b7b6-bf00-240f-f749ebfd913e
   // and https://github.com/MEGA65/mega65-tools/issues/48)
   char device_with_prefix[8192];
-  snprintf(device_with_prefix,8192,"\\\\.\\%s",device);
-  
-  HANDLE port = CreateFileA(device_with_prefix, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  snprintf(device_with_prefix, 8192, "\\\\.\\%s", device);
+
+  HANDLE port = CreateFileA(
+      device_with_prefix, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
   if (port == INVALID_HANDLE_VALUE) {
     print_error(device);
     return INVALID_HANDLE_VALUE;

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -823,7 +823,6 @@ int push_ram(unsigned long address, unsigned int count, unsigned char* buffer)
 
   char cmd[8192];
   for (unsigned int offset = 0; offset < count;) {
-    //printf("%d / %d\n", offset, count);
     int b = count - offset;
     // Limit to same 64KB slab
     if (b > (0xffff - ((address + offset) & 0xffff)))
@@ -917,7 +916,7 @@ int fetch_ram(unsigned long address, unsigned int count, unsigned char* buffer)
       if (s && (strlen(s) >= 42)) {
         char b = s[42];
         s[42] = 0;
-        if (1) {
+        if (0) {
           printf("Found data for $%08x:\n%s\n", (unsigned int)addr, s);
         }
         s[42] = b;

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -1608,6 +1608,7 @@ void open_the_serial_port(char* serial_port)
   fd.fdfile = open_serial_port(serial_port, 2000000);
   if (fd.fdfile == INVALID_HANDLE_VALUE) {
     fprintf(stderr, "Could not open serial port '%s'\n", serial_port);
+    fprintf(stderr, "  (could the port be in use by another application?)\n");
     exit(-1);
   }
 

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -1609,6 +1609,7 @@ void open_the_serial_port(char* serial_port)
   if (fd.fdfile == INVALID_HANDLE_VALUE) {
     fprintf(stderr, "Could not open serial port '%s'\n", serial_port);
     fprintf(stderr, "  (could the port be in use by another application?)\n");
+    fprintf(stderr, "  (could the usb cable be disconnected or faulty?)\n");
     exit(-1);
   }
 

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -136,11 +136,6 @@ void timestamp_msg(char* msg)
 
 int do_slow_write(PORT_TYPE fd, char* d, int l, const char* func, const char* file, const int line)
 {
-  // NOTE: if we're connecting to xemu, slow down the speed of commands sent to
-  // its uart monitor, as it can't handle too many of them in quick succession
-  // if (xemu_flag)
-  //   usleep(500000);
-
   // UART is at 2Mbps, but we need to allow enough time for a whole line of
   // writing. 100 chars x 0.5usec = 500usec. So 1ms between chars should be ok.
   int i;
@@ -173,10 +168,6 @@ int do_slow_write(PORT_TYPE fd, char* d, int l, const char* func, const char* fi
       w = do_serial_port_write(fd, (unsigned char*)&d[i], 1, func, file, line);
     }
   }
-  // NOTE: if we're connecting to xemu, slow down the speed of commands sent to
-  // its uart monitor, as it can't handle too many of them in quick succession
-  // if (xemu_flag)
-  //   usleep(500000);
   return 0;
 }
 
@@ -859,12 +850,6 @@ int push_ram(unsigned long address, unsigned int count, unsigned char* buffer)
           do_usleep(1000 * SLOW_FACTOR);
       }
     }
-
-    // for xemu_flag, try add a pause between successive 'l' commands
-    // to see if it helps with stalling issues
-    // if (xemu_flag)
-    //   do_usleep(5000 * SLOW_FACTOR);
-
     wait_for_prompt();
     offset += b;
   }

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -896,8 +896,8 @@ void job_process_results(void)
         if (fn == 2) {
           if (debug_rx)
             // note that we're hoping that recent[n] and onwards contain the bytes immediately *after* 'FTJOBDATR:%x:%x:'
-            printf("Spotted job data: Reading $%x bytes of raw data (j_addr=$%04X) (offset %d, %02x %02x)\n",
-                   transfer_size, j_addr, n, recent[n], recent[n + 1]);
+            printf("Spotted job data: Reading $%x bytes of raw data (j_addr=$%04X) (offset %d, %02x %02x)\n", transfer_size,
+                j_addr, n, recent[n], recent[n + 1]);
           q_rle_count = 0;
           q_raw_count = 0;
           q_rle_enable = 0;

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -168,9 +168,12 @@ unsigned char syspart_configsector[512];
 int sd_status_fresh = 0;
 unsigned char sd_status[16];
 
+extern const char* version_string;
+
 void usage(void)
 {
   fprintf(stderr, "MEGA65 cross-development tool for FTP-like access to MEGA65 SD card via serial monitor interface\n");
+  fprintf(stderr, "version: %s\n\n", version_string);
   fprintf(stderr, "usage: mega65_ftp [-l <serial port>] [-s <230400|2000000|4000000>]  [-b bitstream] [[-c command] ...]\n");
   fprintf(stderr, "  -l - Name of serial port to use, e.g., /dev/ttyUSB1\n");
   fprintf(stderr, "  -s - Speed of serial port in bits per second. This must match what your bitstream uses.\n");

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -367,13 +367,6 @@ int execute_command(char* cmd)
   if ((!strcmp(cmd, "exit")) || (!strcmp(cmd, "quit"))) {
     printf("Reseting MEGA65 and exiting.\n");
 
-    //for (int i = 0; i < sector_cache_count; i++)
-    //{
-    //  char secname[128];
-    //  sprintf(secname, "\nSector %d:\n", sector_cache_sectors[i]);
-    //  dump_bytes(0, secname, sector_cache[i], 512);
-    //}
-
     restart_hyppo();
     exit(0);
   }
@@ -1102,13 +1095,6 @@ int DIRTYMOCK(read_sector)(const unsigned int sector_number, unsigned char* buff
       //      printf("Sector $%08x:\n",sector_number+n);
       //      dump_bytes(3,"read sector",buffer,512);
 
-      //if (sector_number + n == 2623)
-      //{
-      //  char secname[128];
-      //  sprintf(secname, "\nSector %d:\n", sector_number + n);
-      //  dump_bytes(0, secname, buffer, 512);
-      //}
-
       // Store in cache / update cache
       int i;
       for (i = 0; i < sector_cache_count; i++)
@@ -1121,7 +1107,6 @@ int DIRTYMOCK(read_sector)(const unsigned int sector_number, unsigned char* buff
           sector_cache_count = i + 1;
       }
       else {
-        //printf("SECTOR CACHE OVERFLOW!\n");
         execute_write_queue();
         sector_cache_count = 0;
       }
@@ -1498,8 +1483,6 @@ int chain_cluster(unsigned int cluster, unsigned int next_cluster)
     int fat_sector_offset = (cluster * 4) & 0x1FF;
     if (fat_sector_num >= sectors_per_fat) {
       printf("ERROR: cluster number too large.\n");
-      //printf("  (fat_sector_num >= sectors_per_fat)\n"
-      //       "   (%d >= %d)\n", fat_sector_num, sectors_per_fat);
       retVal = -1;
       break;
     }
@@ -2664,7 +2647,6 @@ int download_file(char* dest_name, char* local_name, int showClusters)
     }
 
     unsigned int first_cluster_of_file = calc_first_cluster_of_file();
-    //printf("first cluster=%08X\n", first_cluster_of_file);
 
     // Now write the file to local disk sector by sector
     int remaining_bytes = de.d_filelen;
@@ -2690,7 +2672,6 @@ int download_file(char* dest_name, char* local_name, int showClusters)
         // If we are currently the last cluster, then allocate a new one, and chain it in
 
         int next_cluster = chained_cluster(file_cluster);
-        //printf("next_cluster=%08X\n", next_cluster);
         if (next_cluster == 0 || next_cluster >= 0xffffff8) {
           printf("\n?  PREMATURE END OF FILE ERROR\n");
           if (f)

--- a/src/utilities/remotesd.c
+++ b/src/utilities/remotesd.c
@@ -36,23 +36,20 @@ uint16_t aa;
 
 void press_key(void)
 {
-      POKE(0xD610, 0);
-      // wait for a key to be pressed
-      printf("press a key to continue...\n");
-      while (!PEEK(0xD610))
-        continue;
-      POKE(0xD610, 0);
+  POKE(0xD610, 0);
+  // wait for a key to be pressed
+  printf("press a key to continue...\n");
+  while (!PEEK(0xD610))
+    continue;
+  POKE(0xD610, 0);
 }
 
-uint8_t c, j, z, pl, job_type, pause_flag=0, xemu_flag=0;
+uint8_t c, j, z, pl, job_type, pause_flag = 0, xemu_flag = 0;
 uint16_t i, job_type_addr;
 
 void check_xemu_flag(void)
 {
-  if (PEEK(0xD632) == 0x58 /* 'X' */ &&
-      PEEK(0xD633) == 0x65 /* 'e' */ &&
-      PEEK(0xD634) == 0x6D /* 'm' */ &&
-      PEEK(0xD635) == 0x75 /* 'u' */) {
+  if (!(PEEK(0xD60F) & 0x20)) {
     printf("Xemu detected!\n");
     xemu_flag = 1;
   }
@@ -62,25 +59,25 @@ void serial_write_string(uint8_t* m, uint16_t len)
 {
 
   for (i = 0; i < len; i++) {
-      SERIAL_DELAY;
-      c = *m;
-      m++;
-      SERIAL_DELAY;
-      SERIAL_WRITE(c);
-      //printf("%02X", c);
-if (pause_flag)
-{
-//#if DEBUG > 1
-      if (i < 368)
-      {
-      printf("%02X", c);
-      if (((i+5)%4) == 0) printf(" ");
-      if (((i+17)%16) == 0) printf("\n");
+    SERIAL_DELAY;
+    c = *m;
+    m++;
+    SERIAL_DELAY;
+    SERIAL_WRITE(c);
+    // printf("%02X", c);
+    if (pause_flag) {
+      //#if DEBUG > 1
+      if (i < 368) {
+        printf("%02X", c);
+        if (((i + 5) % 4) == 0)
+          printf(" ");
+        if (((i + 17) % 16) == 0)
+          printf("\n");
       }
-//#endif
-}
-      if (pause_flag)
-        press_key();
+      //#endif
+    }
+    if (pause_flag)
+      press_key();
   }
 
 #if DEBUG > 1
@@ -299,7 +296,7 @@ void main(void)
     current_time = *(uint16_t*)0xDC08;
     if (current_time != last_advertise_time) {
       // Announce our protocol version
-      //serial_write_string("\nmega65ft1.0\n\r", 14);
+      // serial_write_string("\nmega65ft1.0\n\r", 14);
       last_advertise_time = current_time;
     }
 
@@ -322,7 +319,7 @@ void main(void)
           break;
         job_type_addr = job_addr;
         job_type = PEEK(job_type_addr);
-        printf("job_type=0x%02x\n", job_type);
+        // printf("job_type=0x%02x\n", job_type);
         switch (job_type) {
 
         // - - - - - - - - - - - - - - - - - - - - -
@@ -424,7 +421,7 @@ void main(void)
           sector_number = *(uint32_t*)job_addr;
           job_addr += 4;
 
-#if DEBUG>1
+#if DEBUG > 1
           printf("sector_count = %d\n", sector_count);
           printf("sector_number = $%08lx (%ld)\n", sector_number, sector_number);
           press_key();
@@ -442,7 +439,7 @@ void main(void)
             snprintf(msg, 80, "ftjobdata:%04x:%08lx:", job_type_addr, sector_count * 0x200L);
           else
             snprintf(msg, 80, "ftjobdatr:%04x:%08lx:", job_type_addr, sector_count * 0x200L);
-#if DEBUG>1
+#if DEBUG > 1
           printf("%s\n", msg);
           press_key();
 #endif
@@ -469,7 +466,7 @@ void main(void)
                 sector_number++;
               }
               // add a delay here, to give xemu time to copy across the sector
-              //for (aa = 0; aa < 1000; aa++)
+              // for (aa = 0; aa < 1000; aa++)
               //  continue;
             }
             if (read_pending && (!buffer_ready)) {
@@ -479,7 +476,7 @@ void main(void)
                 // Sector has been read. Copy it to a local buffer for sending,
                 // so that we can send it while reading the next sector
                 lcopy(0xffd6e00, (long)&temp_sector_buffer[0], 0x200);
-                //if (sector_number-1 == 2623)
+                // if (sector_number-1 == 2623)
                 //{
                 //  //pause_flag = 1;
                 //  for (z = 0; z < 16*8; z++)
@@ -512,8 +509,8 @@ void main(void)
             rle_finalise();
 
 #if DEBUG
-          sector_number = *(uint32_t*)(job_addr-4);
-          sector_count = *(uint16_t*)(job_addr-6);
+          sector_number = *(uint32_t*)(job_addr - 4);
+          sector_count = *(uint16_t*)(job_addr - 6);
           printf("$%04x : Completed read sector $%08lx (count=%d)\n", *(uint16_t*)0xDC08, sector_number, sector_count);
 #endif
 
@@ -558,7 +555,7 @@ void main(void)
 
           break;
 
-        // - - - - - - - - - - - - - - - - - - - - -
+          // - - - - - - - - - - - - - - - - - - - - -
 
         default:
           job_addr = 0xd000;

--- a/src/utilities/remotesd.c
+++ b/src/utilities/remotesd.c
@@ -258,7 +258,9 @@ void rle_finalise(void)
 void wait_for_sdcard_to_go_busy(void)
 {
   if (xemu_flag) {
-    // pause a little here, to permit xemu to echo the last command back to mega65_ftp
+    // Pause a little here, to permit xemu to echo the last command back to mega65_ftp.
+    // This need came about due to xemu presently completing SD card jobs instantaneously,
+    // and thus never goes busy.
     for (aa = 0; aa < 20; aa++)
       continue;
   }

--- a/src/utilities/remotesd.c
+++ b/src/utilities/remotesd.c
@@ -465,9 +465,6 @@ void main(void)
 
                 sector_number++;
               }
-              // add a delay here, to give xemu time to copy across the sector
-              // for (aa = 0; aa < 1000; aa++)
-              //  continue;
             }
             if (read_pending && (!buffer_ready)) {
 

--- a/src/utilities/remotesd.c
+++ b/src/utilities/remotesd.c
@@ -24,8 +24,8 @@
 
 // Slight delay between chars for old HYPPO versions that lack ready check on serial write
 #define SERIAL_DELAY
-// #define SERIAL_DELAY for(aa=0;aa!=5;aa++) continue;
-uint8_t aa;
+//#define SERIAL_DELAY for(aa=0;aa!=5;aa++) continue;
+uint16_t aa;
 // Write a char to the serial monitor interface
 #define SERIAL_WRITE(the_char)                                                                                              \
   {                                                                                                                         \
@@ -34,23 +34,46 @@ uint8_t aa;
     __asm__("NOP");                                                                                                         \
   }
 
-uint8_t c, j, pl, job_type;
+void press_key(void)
+{
+      POKE(0xD610, 0);
+      // wait for a key to be pressed
+      printf("press a key to continue...\n");
+      while (!PEEK(0xD610))
+        continue;
+      POKE(0xD610, 0);
+}
+
+uint8_t c, j, z, pl, job_type, pause_flag=0;
 uint16_t i, job_type_addr;
 void serial_write_string(uint8_t* m, uint16_t len)
 {
-  for (i = 0; i < len;) {
-    if (len - i > 255)
-      pl = 255;
-    else
-      pl = len - i;
-    i += pl;
-    for (j = 0; j < pl; j++) {
+
+  for (i = 0; i < len; i++) {
+      SERIAL_DELAY;
       c = *m;
       m++;
       SERIAL_DELAY;
       SERIAL_WRITE(c);
-    }
+      //printf("%02X", c);
+if (pause_flag)
+{
+//#if DEBUG > 1
+      if (i < 368)
+      {
+      printf("%02X", c);
+      if (((i+5)%4) == 0) printf(" ");
+      if (((i+17)%16) == 0) printf("\n");
+      }
+//#endif
+}
+      if (pause_flag)
+        press_key();
   }
+
+#if DEBUG > 1
+  press_key();
+#endif
 }
 
 uint16_t last_advertise_time, current_time;
@@ -102,6 +125,7 @@ void rle_write_string(uint32_t buffer_address, uint32_t transfer_size)
 
     for (bo = 0; bo < block_len; bo++) {
 #if DEBUG > 1
+      // wait for a key to be pressed
       printf("olen=%d, rle_count=%d, last=$%02x, byte=$%02x\n", olen, rle_count, last_value, local_buffer[iofs]);
       while (!PEEK(0xD610))
         continue;
@@ -248,15 +272,20 @@ void main(void)
     current_time = *(uint16_t*)0xDC08;
     if (current_time != last_advertise_time) {
       // Announce our protocol version
-      serial_write_string("\nmega65ft1.0\n\r", 14);
+      //serial_write_string("\nmega65ft1.0\n\r", 14);
       last_advertise_time = current_time;
     }
 
     if (PEEK(0xC000)) {
       // Perform one or more jobs
       job_count = PEEK(0xC000);
+
+      // pause a little here, to permit xemu to echo the last command back to mega65_ftp
+      for (aa = 0; aa < 30000; aa++)
+        continue;
+
 #if DEBUG
-      printf("Received list of %d jobs.\n", job_count);
+      printf("\n\n\nReceived list of %d jobs.\n", job_count);
 #endif
       job_addr = 0xc001;
       for (jid = 0; jid < job_count; jid++) {
@@ -264,6 +293,7 @@ void main(void)
           break;
         job_type_addr = job_addr;
         job_type = PEEK(job_type_addr);
+        printf("job_type=0x%02x\n", job_type);
         switch (job_type) {
         case 0x00:
           job_addr++;
@@ -303,8 +333,8 @@ void main(void)
             POKE(0xD680, 0x06);
 
           // Wait for SD to go busy
-          while (!(PEEK(0xD680) & 0x03))
-            continue;
+          //while (!(PEEK(0xD680) & 0x03))
+          //  continue;
 
           // Wait for SD to read and fiddle border colour to show we are alive
           while (PEEK(0xD680) & 0x03)
@@ -353,6 +383,12 @@ void main(void)
           sector_number = *(uint32_t*)job_addr;
           job_addr += 4;
 
+#if DEBUG>1
+          printf("sector_count = %d\n", sector_count);
+          printf("sector_number = $%08lx (%ld)\n", sector_number, sector_number);
+          press_key();
+#endif
+
           // Begin with no bytes to send
           buffer_ready = 0;
           // and no sector in progress being read
@@ -365,10 +401,15 @@ void main(void)
             snprintf(msg, 80, "ftjobdata:%04x:%08lx:", job_type_addr, sector_count * 0x200L);
           else
             snprintf(msg, 80, "ftjobdatr:%04x:%08lx:", job_type_addr, sector_count * 0x200L);
+#if DEBUG>1
+          printf("%s\n", msg);
+          press_key();
+#endif
           serial_write_string(msg, strlen(msg));
 
           while (sector_count || buffer_ready || read_pending) {
-            if (sector_count && (!read_pending))
+            if (sector_count && (!read_pending)) {
+              // if sd-card is not busy, then do this stuff
               if (!(PEEK(0xD680) & 0x03)) {
                 // Schedule reading of next sector
 
@@ -382,12 +423,24 @@ void main(void)
 
                 POKE(0xD680, 0x02);
                 // Wait for SD card to go busy
-                while (!(PEEK(0xD680) & 0x03)) {
-                  continue;
-                }
+                //while (!(PEEK(0xD680) & 0x03)) {
+                //  continue;
+                //}
+                //__asm__("NOP");
+                //__asm__("NOP");
+                //__asm__("NOP");
+                //__asm__("NOP");
+                //__asm__("NOP");
+                //__asm__("NOP");
+                //__asm__("NOP");
+                //__asm__("NOP");
 
                 sector_number++;
               }
+              // add a delay here, to give xemu time to copy across the sector
+              //for (aa = 0; aa < 1000; aa++)
+              //  continue;
+            }
             if (read_pending && (!buffer_ready)) {
 
               // Read is complete, now queue it for sending back
@@ -395,12 +448,24 @@ void main(void)
                 // Sector has been read. Copy it to a local buffer for sending,
                 // so that we can send it while reading the next sector
                 lcopy(0xffd6e00, (long)&temp_sector_buffer[0], 0x200);
+                //if (sector_number-1 == 2623)
+                //{
+                //  //pause_flag = 1;
+                //  for (z = 0; z < 16*8; z++)
+                //  {
+                //    if ( (z % 8) == 0)
+                //      printf(" ");
+                //    if ( (z % 16) == 0 )
+                //      printf("\n");
+                //    printf("%02X", temp_sector_buffer[z]);
+                //  }
+                //}
+
                 read_pending = 0;
                 buffer_ready = 1;
               }
             }
             if (buffer_ready) {
-
               // XXX - Just send it all in one go, since we don't buffer multiple
               // sectors
               if (job_type == 3)
@@ -408,14 +473,17 @@ void main(void)
               else
                 serial_write_string(temp_sector_buffer, 0x200);
               buffer_ready = 0;
+              pause_flag = 0;
             }
-          }
+          } // end while we have sectors to send
 
           if (job_type == 3)
             rle_finalise();
 
 #if DEBUG
-          printf("$%04x : Read sector $%08lx into mem $%07lx\n", *(uint16_t*)0xDC08, sector_number, buffer_address);
+          sector_number = *(uint32_t*)(job_addr-4);
+          sector_count = *(uint16_t*)(job_addr-6);
+          printf("$%04x : Completed read sector $%08lx (count=%d)\n", *(uint16_t*)0xDC08, sector_number, sector_count);
 #endif
 
           snprintf(msg, 80, "ftjobdone:%04x:\n\r", job_type_addr);


### PR DESCRIPTION
Work done for card #60, to improve comms between tools like m65/mega65_ftp and xemu over tcp port 4510.

For best results, run these tools against my [220-uartmon-update](https://github.com/gurcei/xemu/tree/220-uartmon-update) branch of xemu.

I've left a bit of debug stuff here and there, mostly commented out, particularly in remotesd.c, as I suspect it won't be the last time I need to debug in this vicinity.