### PR TITLE
#69: M65: get '-b' bitstream uploading working in windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ COPT=	-Wall -g -std=gnu99 -I/opt/local/include -L/opt/local/lib -I/usr/local/inc
 CC=	gcc
 CXX=g++
 WINCC=	x86_64-w64-mingw32-gcc
-WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1 -Llibusb-1.0.24/build/libusb/.libs/ -L/mingw64/lib
+WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1
 
 OPHIS=	Ophis/bin/ophis
 OPHISOPT=	-4 --no-warn
@@ -247,8 +247,8 @@ $(UTILDIR)/megaphonenorflash.prg:       $(UTILDIR)/megaphonenorflash.c $(CC65)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(UTILDIR)/remotesd.prg:       $(UTILDIR)/remotesd.c $(CC65)
-	#git submodule init
-	#git submodule update
+	git submodule init
+	git submodule update
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --listing $*.list --mapfile $*.map --add-source $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(TESTDIR)/floppytest.prg:       $(TESTDIR)/floppytest.c $(CC65)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ COPT=	-Wall -g -std=gnu99 -I/opt/local/include -L/opt/local/lib -I/usr/local/inc
 CC=	gcc
 CXX=g++
 WINCC=	x86_64-w64-mingw32-gcc
-WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1
+WINCOPT=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1 -Llibusb-1.0.24/build/libusb/.libs/ -L/mingw64/lib
 
 OPHIS=	Ophis/bin/ophis
 OPHISOPT=	-4 --no-warn
@@ -247,8 +247,8 @@ $(UTILDIR)/megaphonenorflash.prg:       $(UTILDIR)/megaphonenorflash.c $(CC65)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(UTILDIR)/remotesd.prg:       $(UTILDIR)/remotesd.c $(CC65)
-	git submodule init
-	git submodule update
+	#git submodule init
+	#git submodule update
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --listing $*.list --mapfile $*.map --add-source $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(TESTDIR)/floppytest.prg:       $(TESTDIR)/floppytest.c $(CC65)

--- a/src/tools/fpgajtag/fpgajtag.c
+++ b/src/tools/fpgajtag/fpgajtag.c
@@ -785,9 +785,14 @@ void init_fpgajtag(const char* serialno, const char* filename, uint32_t file_idc
       // Iterate through /sys/bus/usb-serial/devices to see if any of the entries there have
       // symlinks that make sense for this device bus and port number.
 #ifdef WINDOWS
-      printf("I'm on windows, and don't (yet) know how to work out the COMx: path.\n");
-      printf("In case it helps: bus=%d, port=%d\n", bus, port);
-      break;
+      // NOTE: I don't think fpgajtag really needs to know the Windows COM port number, so let's skip this
+      // if (!serial_port)
+      // {
+      //   printf("On Windows, please specify COM port for your JTAG connection via the -l argument\n");
+      //   printf("E.g.: m65 -l COM9 -b mybitstream.bit\n");
+      //   printf("In case it helps: bus=%d, port=%d\n", bus, port);
+      //   exit(-1);
+      // }
 #else
       {
         DIR* d = opendir("/sys/bus/usb-serial/devices");

--- a/src/tools/fpgajtag/fpgajtag.c
+++ b/src/tools/fpgajtag/fpgajtag.c
@@ -790,7 +790,7 @@ void init_fpgajtag(const char* serialno, const char* filename, uint32_t file_idc
       // {
       //   printf("On Windows, please specify COM port for your JTAG connection via the -l argument\n");
       //   printf("E.g.: m65 -l COM9 -b mybitstream.bit\n");
-      //   printf("In case it helps: bus=%d, port=%d\n", bus, port);
+      printf("In case it helps: bus=%d, port=%d\n", bus, port);
       //   exit(-1);
       // }
 #else

--- a/src/tools/fpgajtag/util.c
+++ b/src/tools/fpgajtag/util.c
@@ -615,7 +615,11 @@ uint32_t read_inputfile(const char* filename)
   if (!filename)
     return -1;
   if (strcmp(filename, "-")) {
+#ifdef WINDOWS
+    inputfd = open(filename, O_RDONLY | O_BINARY);
+#else
     inputfd = open(filename, O_RDONLY);
+#endif
     if (inputfd == -1) {
       printf("fpgajtag: Unable to open file '%s'\n", filename);
       exit(-1);

--- a/src/tools/fpgajtag/util.c
+++ b/src/tools/fpgajtag/util.c
@@ -381,7 +381,7 @@ USB_INFO* fpgausb_init(void)
     exit(-1);
   }
 
-  //#ifdef LIOBUSB_OPTION_USE_USBDK
+#ifdef LIOBUSB_OPTION_USE_USBDK
   if (usedk) {
     printf("Requesting to use USBDK backend.\n");
     int res = libusb_set_option(usb_context, LIBUSB_OPTION_USE_USBDK);
@@ -389,9 +389,9 @@ USB_INFO* fpgausb_init(void)
       printf("WARNING: Failed to switch to USEDK backend: %s\n", libusb_strerror(res));
     }
   }
-  //#else
-  // #warning No USBDK support in libusb
-  //#endif
+#else
+#warning No USBDK support in libusb
+#endif
 
   while ((dev = device_list[i++])) {
     struct libusb_device_descriptor desc;

--- a/src/tools/fpgajtag/util.c
+++ b/src/tools/fpgajtag/util.c
@@ -381,23 +381,23 @@ USB_INFO* fpgausb_init(void)
     exit(-1);
   }
 
-#ifdef LIOBUSB_OPTION_USE_USBDK
+  //#ifdef LIOBUSB_OPTION_USE_USBDK
   if (usedk) {
     printf("Requesting to use USBDK backend.\n");
     int res = libusb_set_option(usb_context, LIBUSB_OPTION_USE_USBDK);
     if (res < 0) {
-      printf("WARNING: Failed to switch to USEDK backend: %s\n", libusb_strerror(open_result));
+      printf("WARNING: Failed to switch to USEDK backend: %s\n", libusb_strerror(res));
     }
   }
-#else
+  //#else
   // #warning No USBDK support in libusb
-#endif
+  //#endif
 
   while ((dev = device_list[i++])) {
     struct libusb_device_descriptor desc;
     if (libusb_get_device_descriptor(dev, &desc) < 0)
       continue;
-    //	fprintf(stderr,"USB device %04x:%04x\n",desc.idVendor,desc.idProduct);
+    fprintf(stderr, "USB device %04x:%04x\n", desc.idVendor, desc.idProduct);
     if (desc.idVendor == 0x403
         && (desc.idProduct == 0x6001 || desc.idProduct == 0x6010 || desc.idProduct == 0x6011
             || desc.idProduct == 0x6014)) { /* Xilinx */
@@ -408,8 +408,9 @@ USB_INFO* fpgausb_init(void)
       usbinfo_array[usbinfo_array_index].bNumConfigurations = desc.bNumConfigurations;
       int open_result = libusb_open(dev, &usbhandle);
       if (open_result < 0) {
-        printf("ERROR: Could not open USB device: Error code %d\n", open_result);
-        printf("       libusb says: %s\n", libusb_strerror(open_result));
+        fprintf(stderr, "ERROR: Could not open USB device: Error code %d\n", open_result);
+        fprintf(stderr, "       libusb says: %s\n", libusb_strerror(open_result));
+        exit(1);
       }
       else {
         if (UDESC(iManufacturer) < 0 || UDESC(iProduct) < 0 || UDESC(iSerialNumber) < 0) {

--- a/src/tools/fpgajtag/util.c
+++ b/src/tools/fpgajtag/util.c
@@ -74,7 +74,6 @@ static void openlogfile(void);
 
 #include "dumpdata.h"
 
-FILE* logfile;
 int usb_bcddevice;
 uint8_t bitswap[256];
 int last_read_data_length;
@@ -390,7 +389,7 @@ USB_INFO* fpgausb_init(void)
     }
   }
 #else
-#warning No USBDK support in libusb
+//#warning No USBDK support in libusb
 #endif
 
   while ((dev = device_list[i++])) {

--- a/src/tools/fpgajtag/util.c
+++ b/src/tools/fpgajtag/util.c
@@ -396,7 +396,7 @@ USB_INFO* fpgausb_init(void)
     struct libusb_device_descriptor desc;
     if (libusb_get_device_descriptor(dev, &desc) < 0)
       continue;
-    fprintf(stderr, "USB device %04x:%04x\n", desc.idVendor, desc.idProduct);
+    //	fprintf(stderr,"USB device %04x:%04x\n",desc.idVendor,desc.idProduct);
     if (desc.idVendor == 0x403
         && (desc.idProduct == 0x6001 || desc.idProduct == 0x6010 || desc.idProduct == 0x6011
             || desc.idProduct == 0x6014)) { /* Xilinx */

--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -1126,6 +1126,7 @@ void load_bitstream(char* bitstream)
 
           timestamp_msg("");
           fprintf(stderr, "Detected FPGA ID %x from bitstream file.\n", fpga_id);
+          break;
         }
       }
       fclose(f);
@@ -1638,14 +1639,13 @@ int main(int argc, char** argv)
 
           timestamp_msg("");
           fprintf(stderr, "Detected FPGA ID %x from bitstream file.\n", fpga_id);
+          break;
         }
       }
       fclose(f);
     }
     fprintf(stderr, "INFO: Using fpga_id %x\n", fpga_id);
-#ifndef WINDOWS
     init_fpgajtag(NULL, bitstream, fpga_id);
-#endif
   }
 
 #ifdef WINDOWS


### PR DESCRIPTION
Work done for card #69.

The capability to upload bitstreams via m65 in windows is now possible. It's probably best for anyone considering that path to read through my experiences (bad and eventually good) with the zadig tool and installing a winusb driver for "Diligent USB Device (Interface 0)" (and not for (Interface 1)), which I've summarised on card #69 too.