### PR TITLE
#9: MEGA65_FTP: vfat (part 1), extra comfort commands and for accessing filehost easily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -481,11 +481,23 @@ $(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/mega65_ftp.test, $(G
 $(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/bit2core.test, $(GTESTDIR)/bit2core_test.cpp $(TOOLDIR)/bit2core.c))
 
 test: $(GTESTBINDIR)/mega65_ftp.test $(GTESTBINDIR)/bit2core.test
+	@echo ""
+	@echo "TESTING: MEGA65_FTP..."
+	@echo "======================"
 	$(GTESTBINDIR)/mega65_ftp.test
+	@echo ""
+	@echo "TESTING: BIT2CORE..."
+	@echo "===================="
 	$(GTESTBINDIR)/bit2core.test
 
 test.exe: $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTBINDIR)/bit2core.test.exe
+	@echo ""
+	@echo "TESTING: MEGA65_FTP..."
+	@echo "======================"
 	$(GTESTBINDIR)/mega65_ftp.test.exe
+	@echo ""
+	@echo "TESTING: BIT2CORE..."
+	@echo "===================="
 	$(GTESTBINDIR)/bit2core.test.exe
 
 $(BINDIR)/mega65_ftp: $(MEGA65FTP_SRC) Makefile

--- a/Makefile
+++ b/Makefile
@@ -100,27 +100,29 @@ SDCARD_FILES=	$(SDCARD_DIR)/M65UTILS.D81 \
 
 all:	$(SDCARD_FILES) $(TOOLS) $(UTILITIES) $(TESTS)
 
+SUBMODULEUPDATE= \
+	@if [ -z "$(DO_SMU)" ] || [ "$(DO_SMU)" -eq "1" ] ; then \
+	echo "Updating Submodules... (set env-var DO_SMU=0 to turn this behaviour off)" ; \
+	git submodule update --init ; \
+	fi
+
 $(SDCARD_DIR)/FREEZER.M65:
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	( cd src/mega65-freezemenu && make FREEZER.M65 )
 	cp src/mega65-freezemenu/FREEZER.M65 $(SDCARD_DIR)
 
 $(CBMCONVERT):
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	( cd cbmconvert && make -f Makefile.unix )
 
 ifndef USE_LOCAL_CC65
 $(CC65):
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	( cd cc65 && make -j 8 )
 endif
 
 $(OPHIS):
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 
 # c-programs
 tools:	$(TOOLS)
@@ -241,23 +243,19 @@ $(UTILDIR)/mega65_config.prg:       $(UTILDIR)/mega65_config.o $(CC65)
 	$(LD65) $< --mapfile $*.map -o $*.prg
 
 $(UTILDIR)/megaflash.prg:       $(UTILDIR)/megaflash.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(UTILDIR)/megaphonenorflash.prg:       $(UTILDIR)/megaphonenorflash.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(UTILDIR)/remotesd.prg:       $(UTILDIR)/remotesd.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --listing $*.list --mapfile $*.map --add-source $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(TESTDIR)/floppytest.prg:       $(TESTDIR)/floppytest.c $(TESTDIR)/floppyread.s $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s $(TESTDIR)/floppyread.s
 
 $(UTILDIR)/c65toc64wrapper.prg:	$(UTILDIR)/c65toc64wrapper.asm $(ACME)
@@ -267,56 +265,46 @@ $(EXAMPLEDIR)/verticalrasters.prg:	$(EXAMPLEDIR)/verticalrasters.asm $(ACME)
 	$(ACME) --setpc 0x0801 --cpu m65 --format cbm --outfile $(EXAMPLEDIR)/verticalrasters.prg $(EXAMPLEDIR)/verticalrasters.asm
 
 $(UTILDIR)/fastload.prg:       $(UTILDIR)/fastload.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(EXAMPLEDIR)/modplay.prg:       $(EXAMPLEDIR)/modplay.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(TESTDIR)/r3_production_test.prg:       $(TESTDIR)/r3_production_test.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(B65DIR)/wirekrill.prg:       $(EXAMPLEDIR)/wirekrill.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 bin/wirekrill:	$(EXAMPLEDIR)/wirekrill.c
 	$(CC) $(COPT) -DNATIVE_TEST -I/usr/local/include -L/usr/local/lib -o $(BINDIR)/wirekrill $(EXAMPLEDIR)/wirekrill.c -lpcap
 
 $(B65DIR)/cartload.prg:       $(UTILDIR)/cartload.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(B65DIR)/rompatch.prg:       $(UTILDIR)/rompatch.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(EXAMPLEDIR)/raycaster.prg:       $(EXAMPLEDIR)/raycaster.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(TESTDIR)/ultrasoundtest.prg:       $(TESTDIR)/ultrasoundtest.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(TESTDIR)/opcodes65.prg:       $(TESTDIR)/opcodes65.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 $(UTILDIR)/avtest.prg:       $(UTILDIR)/avtest.c $(CC65)
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $<  $(SRCDIR)/mega65-libc/cc65/src/*.c $(SRCDIR)/mega65-libc/cc65/src/*.s
 
 
@@ -376,8 +364,7 @@ $(SRCDIR)/open-roms/build/mega65.rom:	$(SRCDIR)/open-roms/assets/8x8font.png
 	( cd $(SRCDIR)/open-roms ; make build/mega65.rom )
 
 $(SRCDIR)/open-roms/assets/8x8font.png:
-	git submodule init
-	git submodule update
+	$(SUBMODULEUPDATE)
 	( cd $(SRCDIR)/open-roms ; git submodule init ; git submodule update )
 
 $(BINDIR)/asciifont.bin:	$(BINDIR)/pngprepare $(ASSETS)/ascii00-ff.png
@@ -424,10 +411,7 @@ $(BINDIR)/utilpacker:	$(BINDIR)/utilpacker.c Makefile
 	echo "Could not find the program 'convert'. Try the following:"
 	echo "sudo apt-get install imagemagick"
 
-$(TOOLDIR)/version.c: .FORCE
-	echo 'const char *version_string="'`./gitversion.sh`'";' > $(TOOLDIR)/version.c
-
-.FORCE:
+MAKE_VERSION=echo 'const char *version_string="'`./gitversion.sh`'";' > $(TOOLDIR)/version.c
 
 $(SDCARD_DIR)/BANNER.M65:	$(BINDIR)/pngprepare $(ASSETS)/mega65_320x64.png /usr/bin/convert
 	/usr/bin/convert -colors 128 -depth 8 +dither $(ASSETS)/mega65_320x64.png $(BINDIR)/mega65_320x64_128colour.png
@@ -439,14 +423,17 @@ $(BINDIR)/m65ftp_test:	$(TESTDIR)/m65ftp_test.c
 $(BINDIR)/mfm-decode:	$(TOOLDIR)/mfm-decode.c
 	$(CC) $(COPT) -g -Wall -o $(BINDIR)/mfm-decode $(TOOLDIR)/mfm-decode.c
 
-$(BINDIR)/m65:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/*.c $(TOOLDIR)/fpgajtag/*.h Makefile
+$(BINDIR)/m65:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/*.c $(TOOLDIR)/fpgajtag/*.h Makefile
+	$(MAKE_VERSION)
 	$(CC) $(COPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -o $(BINDIR)/m65 $(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/fpgajtag.c $(TOOLDIR)/fpgajtag/util.c $(TOOLDIR)/fpgajtag/process.c -lusb-1.0 -lz -lpthread -lpng
 
-$(BINDIR)/m65.osx:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/*.c $(TOOLDIR)/fpgajtag/*.h Makefile
+$(BINDIR)/m65.osx:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/*.c $(TOOLDIR)/fpgajtag/*.h Makefile
+	$(MAKE_VERSION)
 	$(CC) $(COPT) -D__APPLE__ -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -o $(BINDIR)/m65.osx $(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/fpgajtag.c $(TOOLDIR)/fpgajtag/util.c $(TOOLDIR)/fpgajtag/process.c -lusb-1.0 -lz -lpthread -lpng
 
 
-$(BINDIR)/m65.exe:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/*.c $(TOOLDIR)/fpgajtag/*.h Makefile
+$(BINDIR)/m65.exe:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/*.c $(TOOLDIR)/fpgajtag/*.h Makefile
+	$(MAKE_VERSION)
 	$(WINCC) $(WINCOPT) -g -Wall -Iinclude `pkg-config --cflags libusb-1.0` -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/m65.exe $(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/fpgajtag.c $(TOOLDIR)/fpgajtag/util.c $(TOOLDIR)/fpgajtag/process.c -Wl,-Bstatic -lusb-1.0 -lwsock32 -lws2_32 -lpng -lz -Wl,-Bdynamic
 # $(TOOLDIR)/fpgajtag/listComPorts.c $(TOOLDIR)/fpgajtag/disphelper.c
 
@@ -458,21 +445,23 @@ $(TOOLDIR)/ftphelper.c:	$(UTILDIR)/remotesd.prg $(TOOLDIR)/bin2c
 
 define LINUX_AND_MINGW_GTEST_TARGETS
 $(1): $(2)
-	$$(CXX) $$(COPT) $$(GTESTOPTS) -Iinclude -o $$@ $$(filter %.c %.cpp,$$^) -lreadline -lncurses -lgtest_main -lgtest -lpthread
+	$$(MAKE_VERSION)
+	$$(CXX) $$(COPT) $$(GTESTOPTS) -Iinclude -o $$@ $$(filter %.c %.cpp,$$^) $(TOOLDIR)/version.c -lreadline -lncurses -lgtest_main -lgtest -lpthread
 
 $(1).exe: $(2)
-	$$(CXX) $$(WINCOPT) $$(GTESTOPTS) -Iinclude -o $$@ $$(filter %.c %.cpp,$$^) -lreadline -lncurses -lgtest_main -lgtest -lpthread -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
+	$$(MAKE_VERSION)
+	$$(CXX) $$(WINCOPT) $$(GTESTOPTS) -Iinclude -o $$@ $$(filter %.c %.cpp,$$^) $(TOOLDIR)/version.c -lreadline -lncurses -lgtest_main -lgtest -lpthread -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
 endef
 
 # Gives two targets of:
 # - gtest/bin/mega65_ftp.test
 # - gtest/bin/mega65_ftp.test.exe
-$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/mega65_ftp.test, $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c Makefile))
+$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/mega65_ftp.test, $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c Makefile))
 
 # Gives two targets of:
 # - gtest/bin/bit2core.test
 # - gtest/bin/bit2core.test.exe
-$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/bit2core.test, $(GTESTDIR)/bit2core_test.cpp $(TOOLDIR)/bit2core.c $(TOOLDIR)/version.c))
+$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/bit2core.test, $(GTESTDIR)/bit2core_test.cpp $(TOOLDIR)/bit2core.c))
 
 test: $(GTESTBINDIR)/mega65_ftp.test $(GTESTBINDIR)/bit2core.test
 	$(GTESTBINDIR)/mega65_ftp.test
@@ -482,16 +471,20 @@ test.exe: $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTBINDIR)/bit2core.test.exe
 	$(GTESTBINDIR)/mega65_ftp.test.exe
 	$(GTESTBINDIR)/bit2core.test.exe
 
-$(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c
+$(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
+	$(MAKE_VERSION)
 	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c -Wl,-Bstatic -lreadline -lncurses -ltinfo -Wl,-Bdynamic
 
-$(BINDIR)/mega65_ftp.static:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a
+$(BINDIR)/mega65_ftp.static:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a
+	$(MAKE_VERSION)
 	$(CC) $(COPT) -Iinclude -mno-sse3 -o $(BINDIR)/mega65_ftp.static $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a -ltermcap
 
-$(BINDIR)/mega65_ftp.exe:	$(TOOLDIR)/mega65_ftp.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c
+$(BINDIR)/mega65_ftp.exe:	$(TOOLDIR)/mega65_ftp.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/m65common.c
+	$(MAKE_VERSION)
 	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
 
-$(BINDIR)/mega65_ftp.osx:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/ftphelper.c Makefile $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c
+$(BINDIR)/mega65_ftp.osx:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/ftphelper.c Makefile $(TOOLDIR)/m65common.c
+	$(MAKE_VERSION)
 	$(CC) $(COPT) -D__APPLE__ -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -o $(BINDIR)/mega65_ftp.osx $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c -lusb-1.0 -lz -lpthread -lreadline
 
 $(BINDIR)/bitinfo:	$(TOOLDIR)/bitinfo.c Makefile 
@@ -503,16 +496,18 @@ $(BINDIR)/bitinfo:	$(TOOLDIR)/bitinfo.c Makefile
 # arg2 = pre-requisites
 define LINUX_AND_MINGW_TARGETS
 $(1): $(2)
-	$$(CC) -g -Wall -Iinclude -o $$@ $$(filter %.c,$$^)
+	$$(MAKE_VERSION)
+	$$(CC) -g -Wall -Iinclude -o $$@ $$(filter %.c,$$^) $(TOOLDIR)/version.c
 
 $(1).exe: $(2)
-	$$(WINCC) $$(WINCOPT) -g -Wall -Iinclude -o $$@ $$(filter %.c,$$^)
+	$$(MAKE_VERSION)
+	$$(WINCC) $$(WINCOPT) -g -Wall -Iinclude -o $$@ $$(filter %.c,$$^) $(TOOLDIR)/version.c
 endef
 
 # Creates 2 targets:
 # - bin/bit2core (for linux)
 # - bin/bit2core.exe (for mingw)
-$(eval $(call LINUX_AND_MINGW_TARGETS, $(BINDIR)/bit2core, $(TOOLDIR)/bit2core.c $(TOOLDIR)/version.c Makefile))
+$(eval $(call LINUX_AND_MINGW_TARGETS, $(BINDIR)/bit2core, $(TOOLDIR)/bit2core.c Makefile))
 
 $(BINDIR)/bit2mcs:	$(TOOLDIR)/bit2mcs.c Makefile 
 	$(CC) $(COPT) -g -Wall -o $(BINDIR)/bit2mcs $(TOOLDIR)/bit2mcs.c

--- a/Makefile
+++ b/Makefile
@@ -471,21 +471,27 @@ test.exe: $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTBINDIR)/bit2core.test.exe
 	$(GTESTBINDIR)/mega65_ftp.test.exe
 	$(GTESTBINDIR)/bit2core.test.exe
 
-$(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c
-	$(MAKE_VERSION)
-	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c $(TOOLDIR)/version.c -Wl,-Bstatic -lreadline -lncurses -ltinfo -Wl,-Bdynamic
+MEGA65FTP_SRC=$(TOOLDIR)/mega65_ftp.c \
+							$(TOOLDIR)/m65common.c \
+							$(TOOLDIR)/ftphelper.c \
+							$(TOOLDIR)/filehost.c \
+							$(TOOLDIR)/diskman.c
 
-$(BINDIR)/mega65_ftp.static:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a
+$(BINDIR)/mega65_ftp: $(MEGA65FTP_SRC) Makefile
 	$(MAKE_VERSION)
-	$(CC) $(COPT) -Iinclude -mno-sse3 -o $(BINDIR)/mega65_ftp.static $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c $(TOOLDIR)/version.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a -ltermcap
+	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(MEGA65FTP_SRC) $(TOOLDIR)/version.c -Wl,-Bstatic -lreadline -lncurses -ltinfo -Wl,-Bdynamic
 
-$(BINDIR)/mega65_ftp.exe:	$(TOOLDIR)/mega65_ftp.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/m65common.c $(TOOLDIR)/filehost.c
+$(BINDIR)/mega65_ftp.static: $(MEGA65FTP_SRC) Makefile ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a
 	$(MAKE_VERSION)
-	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c $(TOOLDIR)/version.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
+	$(CC) $(COPT) -Iinclude -mno-sse3 -o $(BINDIR)/mega65_ftp.static $(MEGA65FTP_SRC) $(TOOLDIR)/version.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a -ltermcap
 
-$(BINDIR)/mega65_ftp.osx:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/ftphelper.c Makefile $(TOOLDIR)/m65common.c $(TOOLDIR)/filehost.c
+$(BINDIR)/mega65_ftp.exe: $(MEGA65FTP_SRC) Makefile 
 	$(MAKE_VERSION)
-	$(CC) $(COPT) -D__APPLE__ -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -o $(BINDIR)/mega65_ftp.osx $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c $(TOOLDIR)/version.c -lusb-1.0 -lz -lpthread -lreadline
+	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(MEGA65FTP_SRC) $(TOOLDIR)/version.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
+
+$(BINDIR)/mega65_ftp.osx: $(MEGA65FTP_SRC) Makefile 
+	$(MAKE_VERSION)
+	$(CC) $(COPT) -D__APPLE__ -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -o $(BINDIR)/mega65_ftp.osx $(MEGA65FTP_SRC) $(TOOLDIR)/version.c -lusb-1.0 -lz -lpthread -lreadline
 
 $(BINDIR)/bitinfo:	$(TOOLDIR)/bitinfo.c Makefile 
 	$(CC) $(COPT) -g -Wall -o $(BINDIR)/bitinfo $(TOOLDIR)/bitinfo.c

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,13 @@ else
 	CC65_PREFIX=$(PWD)/cc65/bin/
 endif
 
+BUILD_STATIC=-Wl,-Bstatic
+
+ifeq ($(DO_STATIC), 0)
+	# Does user want compile dynamically? (faster, better during development)
+	BUILD_STATIC=
+endif
+
 CC65=  $(CC65_PREFIX)cc65
 CA65=  $(CC65_PREFIX)ca65 --cpu 4510
 LD65=  $(CC65_PREFIX)ld65 -t none
@@ -387,7 +394,7 @@ $(BINDIR)/romdiff:	$(TOOLDIR)/romdiff.c Makefile
 	$(CC) $(COPT) -O3 -I/usr/local/include -L/usr/local/lib -o $(BINDIR)/romdiff $(TOOLDIR)/romdiff.c
 
 $(BINDIR)/romdiff.exe:	$(TOOLDIR)/romdiff.c Makefile
-	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/romdiff.exe $(TOOLDIR)/romdiff.c -Wl,-Bstatic -Wl,-Bdynamic
+	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/romdiff.exe $(TOOLDIR)/romdiff.c $(BUILD_STATIC) -Wl,-Bdynamic
 
 $(BINDIR)/romdiff.osx:	$(TOOLDIR)/romdiff.c Makefile
 	$(CC) $(COPT) -D__APPLE__ -g -Wall -Iinclude -o $(BINDIR)/romdiff.osx $(TOOLDIR)/romdiff.c
@@ -411,7 +418,11 @@ $(BINDIR)/utilpacker:	$(BINDIR)/utilpacker.c Makefile
 	echo "Could not find the program 'convert'. Try the following:"
 	echo "sudo apt-get install imagemagick"
 
-MAKE_VERSION=echo 'const char *version_string="'`./gitversion.sh`'";' > $(TOOLDIR)/version.c
+MAKE_VERSION= \
+	@if [ -z "$(DO_MKVER)" ] || [ "$(DO_MKVER)" -eq "1" ] ; then \
+	echo "Retrieving Git version string... (set env-var DO_MKVER=0 to turn this behaviour off)" ; \
+	echo 'const char *version_string="'`./gitversion.sh`'";' > $(TOOLDIR)/version.c ; \
+	fi
 
 $(SDCARD_DIR)/BANNER.M65:	$(BINDIR)/pngprepare $(ASSETS)/mega65_320x64.png /usr/bin/convert
 	/usr/bin/convert -colors 128 -depth 8 +dither $(ASSETS)/mega65_320x64.png $(BINDIR)/mega65_320x64_128colour.png
@@ -434,7 +445,7 @@ $(BINDIR)/m65.osx:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/screen_sho
 
 $(BINDIR)/m65.exe:	$(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/*.c $(TOOLDIR)/fpgajtag/*.h Makefile
 	$(MAKE_VERSION)
-	$(WINCC) $(WINCOPT) -g -Wall -Iinclude `pkg-config --cflags libusb-1.0` -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/m65.exe $(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/fpgajtag.c $(TOOLDIR)/fpgajtag/util.c $(TOOLDIR)/fpgajtag/process.c -Wl,-Bstatic -lusb-1.0 -lwsock32 -lws2_32 -lpng -lz -Wl,-Bdynamic
+	$(WINCC) $(WINCOPT) -g -Wall -Iinclude `pkg-config --cflags libusb-1.0` -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/m65.exe $(TOOLDIR)/m65.c $(TOOLDIR)/m65common.c $(TOOLDIR)/version.c $(TOOLDIR)/screen_shot.c $(TOOLDIR)/fpgajtag/fpgajtag.c $(TOOLDIR)/fpgajtag/util.c $(TOOLDIR)/fpgajtag/process.c $(BUILD_STATIC) -lusb-1.0 -lwsock32 -lws2_32 -lpng -lz -Wl,-Bdynamic
 # $(TOOLDIR)/fpgajtag/listComPorts.c $(TOOLDIR)/fpgajtag/disphelper.c
 
 $(LIBEXECDIR)/ftphelper.bin:	$(TOOLDIR)/ftphelper.a65
@@ -450,13 +461,19 @@ $(1): $(2)
 
 $(1).exe: $(2)
 	$$(MAKE_VERSION)
-	$$(CXX) $$(WINCOPT) $$(GTESTOPTS) -Iinclude -o $$@ $$(filter %.c %.cpp,$$^) $(TOOLDIR)/version.c -lreadline -lncurses -lgtest_main -lgtest -lpthread -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
+	$$(CXX) $$(WINCOPT) $$(GTESTOPTS) -Iinclude -o $$@ $$(filter %.c %.cpp,$$^) $(TOOLDIR)/version.c -lreadline -lncurses -lgtest_main -lgtest -lpthread $$(BUILD_STATIC) -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
 endef
+
+MEGA65FTP_SRC=$(TOOLDIR)/mega65_ftp.c \
+							$(TOOLDIR)/m65common.c \
+							$(TOOLDIR)/ftphelper.c \
+							$(TOOLDIR)/filehost.c \
+							$(TOOLDIR)/diskman.c
 
 # Gives two targets of:
 # - gtest/bin/mega65_ftp.test
 # - gtest/bin/mega65_ftp.test.exe
-$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/mega65_ftp.test, $(GTESTDIR)/mega65_ftp_test.cpp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c Makefile))
+$(eval $(call LINUX_AND_MINGW_GTEST_TARGETS, $(GTESTBINDIR)/mega65_ftp.test, $(GTESTDIR)/mega65_ftp_test.cpp $(MEGA65FTP_SRC) Makefile))
 
 # Gives two targets of:
 # - gtest/bin/bit2core.test
@@ -471,15 +488,9 @@ test.exe: $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTBINDIR)/bit2core.test.exe
 	$(GTESTBINDIR)/mega65_ftp.test.exe
 	$(GTESTBINDIR)/bit2core.test.exe
 
-MEGA65FTP_SRC=$(TOOLDIR)/mega65_ftp.c \
-							$(TOOLDIR)/m65common.c \
-							$(TOOLDIR)/ftphelper.c \
-							$(TOOLDIR)/filehost.c \
-							$(TOOLDIR)/diskman.c
-
 $(BINDIR)/mega65_ftp: $(MEGA65FTP_SRC) Makefile
 	$(MAKE_VERSION)
-	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(MEGA65FTP_SRC) $(TOOLDIR)/version.c -Wl,-Bstatic -lreadline -lncurses -ltinfo -Wl,-Bdynamic
+	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(MEGA65FTP_SRC) $(TOOLDIR)/version.c $(BUILD_STATIC) -lreadline -lncurses -ltinfo -Wl,-Bdynamic
 
 $(BINDIR)/mega65_ftp.static: $(MEGA65FTP_SRC) Makefile ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a
 	$(MAKE_VERSION)
@@ -487,7 +498,7 @@ $(BINDIR)/mega65_ftp.static: $(MEGA65FTP_SRC) Makefile ncurses/lib/libncurses.a 
 
 $(BINDIR)/mega65_ftp.exe: $(MEGA65FTP_SRC) Makefile 
 	$(MAKE_VERSION)
-	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(MEGA65FTP_SRC) $(TOOLDIR)/version.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
+	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(MEGA65FTP_SRC) $(TOOLDIR)/version.c -lusb-1.0 $(BUILD_STATIC) -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
 
 $(BINDIR)/mega65_ftp.osx: $(MEGA65FTP_SRC) Makefile 
 	$(MAKE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -471,21 +471,21 @@ test.exe: $(GTESTBINDIR)/mega65_ftp.test.exe $(GTESTBINDIR)/bit2core.test.exe
 	$(GTESTBINDIR)/mega65_ftp.test.exe
 	$(GTESTBINDIR)/bit2core.test.exe
 
-$(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c
+$(BINDIR)/mega65_ftp:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c
 	$(MAKE_VERSION)
-	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c -Wl,-Bstatic -lreadline -lncurses -ltinfo -Wl,-Bdynamic
+	$(CC) $(COPT) -Iinclude -o $(BINDIR)/mega65_ftp $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c $(TOOLDIR)/version.c -Wl,-Bstatic -lreadline -lncurses -ltinfo -Wl,-Bdynamic
 
-$(BINDIR)/mega65_ftp.static:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a
+$(BINDIR)/mega65_ftp.static:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a
 	$(MAKE_VERSION)
-	$(CC) $(COPT) -Iinclude -mno-sse3 -o $(BINDIR)/mega65_ftp.static $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a -ltermcap
+	$(CC) $(COPT) -Iinclude -mno-sse3 -o $(BINDIR)/mega65_ftp.static $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c $(TOOLDIR)/version.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a -ltermcap
 
-$(BINDIR)/mega65_ftp.exe:	$(TOOLDIR)/mega65_ftp.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/m65common.c
+$(BINDIR)/mega65_ftp.exe:	$(TOOLDIR)/mega65_ftp.c Makefile $(TOOLDIR)/ftphelper.c $(TOOLDIR)/m65common.c $(TOOLDIR)/filehost.c
 	$(MAKE_VERSION)
-	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
+	$(WINCC) $(WINCOPT) -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c $(TOOLDIR)/version.c -lusb-1.0 -Wl,-Bstatic -lwsock32 -lws2_32 -lz -Wl,-Bdynamic
 
-$(BINDIR)/mega65_ftp.osx:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/ftphelper.c Makefile $(TOOLDIR)/m65common.c
+$(BINDIR)/mega65_ftp.osx:	$(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/ftphelper.c Makefile $(TOOLDIR)/m65common.c $(TOOLDIR)/filehost.c
 	$(MAKE_VERSION)
-	$(CC) $(COPT) -D__APPLE__ -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -o $(BINDIR)/mega65_ftp.osx $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/version.c -lusb-1.0 -lz -lpthread -lreadline
+	$(CC) $(COPT) -D__APPLE__ -g -Wall -Iinclude -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local//Cellar/libusb/1.0.18/include/libusb-1.0/ -o $(BINDIR)/mega65_ftp.osx $(TOOLDIR)/mega65_ftp.c $(TOOLDIR)/m65common.c $(TOOLDIR)/ftphelper.c $(TOOLDIR)/filehost.c $(TOOLDIR)/version.c -lusb-1.0 -lz -lpthread -lreadline
 
 $(BINDIR)/bitinfo:	$(TOOLDIR)/bitinfo.c Makefile 
 	$(CC) $(COPT) -g -Wall -o $(BINDIR)/bitinfo $(TOOLDIR)/bitinfo.c

--- a/gtest/bit2core_test.cpp
+++ b/gtest/bit2core_test.cpp
@@ -41,7 +41,7 @@ void generate_dummy_bit_file(const char* name, const char* m65targetname)
   fputc('b', f);
 
   // fpga part-id
-  int len = strlen(fpga_part)+1;
+  int len = strlen(fpga_part) + 1;
   fputc((len >> 8) & 0xff, f);
   fputc(len & 0xff, f);
   fprintf(f, fpga_part);

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -241,4 +241,56 @@ TEST_F(Mega65FtpTestFixture, PutCommandWritesFileToContiguousClusters)
   ASSERT_EQ(0, is_fragmented(file8kb));
 }
 
+TEST(Mega65FtpTest, RenameToAnExistingFilenameShouldNotBePermitted)
+{
+  upload_file("file1.txt");
+  upload_file("file2.txt");
+  rename_file("file1.txt", "file2.txt");
+  // this should result in an error
+}
+
+TEST(Mega65FtpTest, UploadNewLFNShouldOfferShortName)
+{
+  upload_file("LongFileName.d81", "LongFileName.d81");
+  // assess_shortname = "LONGFI~1.D81"
+}
+
+TEST(Mega65FtpTest, UploadNewLFNShouldCreateLFNAndShortNameDirEntries)
+{
+  upload_file("LongFileName.d81", "LongFileName.d81");
+  // examine dir-entries for file and assess validity of LFN and 8.3 ShortName
+}
+
+TEST(Mega65FtpTest, DeleteLFNShouldDeleteLFNAndShortNameDirEntries)
+{
+  upload_file("LongFileName.d81", "LongFileName.d81");
+  // as with test above, assure the dir-entries exist
+  delete_file("LongFileName.d81");
+  // now assess that dir-entries have been removed
+}
+
+TEST(Mega65FtpTest, RenameLFNToAnotherLFNShouldRenameLFNAndShortNameDirEntries)
+{
+  upload_file("LongFileName.d81", "LongFileName.d81");
+  // as with test above, assure the dir-entries exist
+  rename_file("LongFileName.d81", "AnotherLongFileName.d81");
+  // now assess that dir-entries for LFN and 8.3 shortname have been updated
+}
+
+TEST(Mega65FtpTest, UploadSameLFNWithExistingShortNameShouldOverwrite)
+{
+  upload_file("LongFileName.d81", "LongFileName.d81");
+  upload_file("LongFileName2.d81", "LongFileName.d81");
+  download_file("LongFileName.d81");
+  // it should match the contents of LongFileName2.d81
+}
+
+TEST(Mega65FtpTest, UploadDifferentLFNWithExistingShortNameShouldUseDifferentName)
+{
+  upload_file("LongFileName.d81"); // This will be 'LONGFI~1.D81'
+  upload_file("LongFish.d81");   // This should be 'LONGFI~2.D81'
+  download("LONGFI~2.D81");
+  // assure its contents matches 'LongFish.d81'
+}
+
 } // namespace mega65_ftp

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -7,6 +7,7 @@ int upload_file(char* name, char* dest_name);
 int rename_file(char* name, char* dest_name);
 int delete_file(char* name);
 int download_file(char* dest_name, char* local_name, int showClusters);
+int open_file_system(void);
 int is_fragmented(char* filename);
 
 #define SECTOR_SIZE 512
@@ -22,6 +23,8 @@ unsigned char sdcard[SDSIZE] = { 0 };
 
 void init_sdcard_data(void)
 {
+  memset(sdcard, 0, SDSIZE);
+
   // MBR
   // ===
   // - Describe the 1st (and only) partition
@@ -253,7 +256,18 @@ TEST_F(Mega65FtpTestFixture, PutCommandWritesFileToContiguousClusters)
   ASSERT_EQ(0, is_fragmented(file8kb));
 }
 
-TEST_F(Mega65FtpTestFixture, RenameToAnExistingFilenameShouldNotBePermitted)
+TEST_F(Mega65FtpTestFixture, RenameToNonExistingFilenameShouldBePermitted)
+{
+  init_sdcard_data();
+  upload_file(file4kb, file4kb);
+  int ret = rename_file(file4kb, file8kb);
+  // this should result in an error
+
+  ReleaseStdOut();
+  ASSERT_EQ(ret, 0);
+}
+
+TEST_F(Mega65FtpTestFixture, RenameToExistingFilenameShouldNotBePermitted)
 {
   init_sdcard_data();
   upload_file(file4kb, file4kb);

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -199,8 +199,7 @@ class Mega65FtpTestFixture : public ::testing::Test {
 
   void ReleaseStdOut(void)
   {
-    if (suppressflag)
-    {
+    if (suppressflag) {
       suppressflag = 0;
       testing::internal::GetCapturedStderr();
       testing::internal::GetCapturedStdout();
@@ -261,7 +260,6 @@ TEST_F(Mega65FtpTestFixture, RenameToAnExistingFilenameShouldNotBePermitted)
   upload_file(file8kb, file8kb);
   int ret = rename_file(file4kb, file8kb);
   // this should result in an error
-  
 
   ReleaseStdOut();
   ASSERT_EQ(ret, -2);

--- a/gtest/mega65_ftp_test.cpp
+++ b/gtest/mega65_ftp_test.cpp
@@ -8,6 +8,7 @@ int rename_file(char* name, char* dest_name);
 int delete_file(char* name);
 int download_file(char* dest_name, char* local_name, int showClusters);
 int open_file_system(void);
+int contains_file(char* name);
 int is_fragmented(char* filename);
 
 #define SECTOR_SIZE 512
@@ -260,11 +261,10 @@ TEST_F(Mega65FtpTestFixture, RenameToNonExistingFilenameShouldBePermitted)
 {
   init_sdcard_data();
   upload_file(file4kb, file4kb);
-  int ret = rename_file(file4kb, file8kb);
-  // this should result in an error
+  rename_file(file4kb, file8kb);
 
   ReleaseStdOut();
-  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(1, contains_file(file8kb));
 }
 
 TEST_F(Mega65FtpTestFixture, RenameToExistingFilenameShouldNotBePermitted)

--- a/include/m65common.h
+++ b/include/m65common.h
@@ -98,6 +98,7 @@ extern PORT_TYPE fd;
 extern int serial_speed;
 extern int saw_c64_mode;
 extern int saw_c65_mode;
+extern int saw_openrom;
 extern int xemu_flag;
 
 #endif // M65COMMON_H

--- a/include/m65common.h
+++ b/include/m65common.h
@@ -70,7 +70,10 @@ void set_serial_speed(int fd, int serial_speed);
 #endif
 void open_the_serial_port(char* serial_port);
 int switch_to_c64mode(void);
-void close_tcp_port(void);
+PORT_TYPE open_tcp_port(char* portname);
+void close_tcp_port(PORT_TYPE localfd);
+void do_write(PORT_TYPE localfd, char* str);
+int do_read(PORT_TYPE localfd, char* str, int max);
 
 #ifdef WINDOWS
 #define bzero(b, len) (memset((b), '\0', (len)), (void)0)

--- a/include/m65common.h
+++ b/include/m65common.h
@@ -95,5 +95,6 @@ extern PORT_TYPE fd;
 extern int serial_speed;
 extern int saw_c64_mode;
 extern int saw_c65_mode;
+extern int xemu_flag;
 
 #endif // M65COMMON_H

--- a/include/m65common.h
+++ b/include/m65common.h
@@ -72,6 +72,7 @@ void open_the_serial_port(char* serial_port);
 int switch_to_c64mode(void);
 PORT_TYPE open_tcp_port(char* portname);
 void close_tcp_port(PORT_TYPE localfd);
+void close_default_tcp_port(void);
 void do_write(PORT_TYPE localfd, char* str);
 int do_read(PORT_TYPE localfd, char* str, int max);
 
@@ -82,6 +83,7 @@ void do_usleep(__int64 usec);
 #else
 #include <termios.h>
 void do_usleep(unsigned long usec);
+int stricmp(const char *a, const char *b);
 #endif
 
 #ifdef __APPLE__

--- a/src/tools/diskman.c
+++ b/src/tools/diskman.c
@@ -156,7 +156,7 @@ void update_tsptr(int track, int sector, int t, int s)
   dest[1] = s;
 }
 
-void write_sector(int track, int sector, char* chunk)
+static void write_sector(int track, int sector, char* chunk)
 {
   char* dest = &data[(track-1)*(256*40) + sector*256];
   memcpy(dest, chunk, 256);
@@ -228,7 +228,9 @@ char* create_d81_for_prg(char* prgfname)
   return d81name;
 }
 
+/*
 void main(void)
 {
   create_d81_for_prg("momo.prg");
 }
+*/

--- a/src/tools/diskman.c
+++ b/src/tools/diskman.c
@@ -1,0 +1,234 @@
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+char data[819200];
+
+void write_tso_byte(int track, int sector, int offset, int val)
+{
+  data[(track-1)*(256*40) + sector*256 + offset] = val;
+}
+
+void write_tso_str(int track, int sector, int offset, char* str, int maxlen)
+{
+  char* pstr = str;
+  for (int k = 0; k < maxlen; k++)
+  {
+    int val = 0xa0; // assume padding byte
+    if (*pstr != '\0')
+    {
+      val = *pstr;
+      pstr++;
+    }
+    write_tso_byte(track, sector, offset+k, val);
+  }
+}
+
+void write_header(char* disk_name, char* disk_id)
+{
+  write_tso_byte(40, 0, 0x00, 40); // write T/S location of first directory sector
+  write_tso_byte(40, 0, 0x01, 3);
+  write_tso_byte(40, 0, 0x02, 0x44); // Disk DOS version type 'D' = 1581
+  write_tso_byte(40, 0, 0x03, 0);
+  write_tso_str (40, 0, 0x04, disk_name, 16);
+  write_tso_byte(40, 0, 0x14, 0xA0);
+  write_tso_byte(40, 0, 0x15, 0xA0);
+  write_tso_str (40, 0, 0x16, disk_id, 2);
+  write_tso_byte(40, 0, 0x18, 0xA0);
+  write_tso_byte(40, 0, 0x19, '3');
+  write_tso_byte(40, 0, 0x1A, 'D');
+  write_tso_byte(40, 0, 0x1B, 0xA0);
+  write_tso_byte(40, 0, 0x1C, 0xA0);
+
+  // some BAM initialisation too
+  write_tso_byte(40, 1, 0x00, 40);  // next bam t/s
+  write_tso_byte(40, 1, 0x01, 2);
+  write_tso_byte(40, 1, 0x02, 'D');
+  write_tso_byte(40, 1, 0x03, 0xBB);
+  write_tso_str (40, 1, 0x04, disk_id, 2);
+  write_tso_byte(40, 1, 0x06, 0xC0); // verify on, check header crc
+  write_tso_byte(40, 1, 0x07, 0x00);  // auto-bootloader flag?
+  // initialise bam entries for tracks (set all sectors as empty)
+  for (int k = 0; k < 40; k++)
+    write_tso_str(40, 1, 0x10 + k*6, "\x28\xff\xff\xff\xff\xff", 6);
+
+  write_tso_byte(40, 2, 0x00, 0x00);  // next bam t/s (0x00 0xff is last one)
+  write_tso_byte(40, 2, 0x01, 0xff);
+  write_tso_byte(40, 2, 0x02, 'D');
+  write_tso_byte(40, 2, 0x03, 0xBB);
+  write_tso_str (40, 2, 0x04, disk_id, 2);
+  write_tso_byte(40, 2, 0x06, 0xC0); // verify on, check header crc
+  write_tso_byte(40, 2, 0x07, 0x00);  // auto-bootloader flag?
+  // initialise bam entries for tracks (set all sectors as empty)
+  for (int k = 0; k < 40; k++)
+    write_tso_str(40, 2, 0x10 + k*6, "\x28\xff\xff\xff\xff\xff", 6);
+}
+
+#define FTYPE_DEL 0
+#define FTYPE_SEQ 1
+#define FTYPE_PRG 2
+#define FTYPE_USR 3
+#define FTYPE_REL 4
+#define FTYPE_CBM 5
+#define FTYPE_CLOSEDFLAG  0x80
+
+void write_direntry(char* prgname, int firsttrack, int firstsector, int sectorcnt)
+{
+  write_tso_byte(40, 3, 0x00, 0x00); // write T/S location of next dir-entry sector (0x00 and 0xff for last sector)
+  write_tso_byte(40, 3, 0x01, 0xff);
+  write_tso_byte(40, 3, 0x02, FTYPE_PRG | FTYPE_CLOSEDFLAG);
+  write_tso_byte(40, 3, 0x03, firsttrack);
+  write_tso_byte(40, 3, 0x04, firstsector);
+  write_tso_str (40, 3, 0x05, prgname, 16);
+  write_tso_byte(40, 3, 0x15, 0x00);
+  write_tso_byte(40, 3, 0x16, 0x00);
+  write_tso_byte(40, 3, 0x17, 0x00);
+  write_tso_byte(40, 3, 0x1E, sectorcnt & 0xff);
+  write_tso_byte(40, 3, 0x1F, sectorcnt >> 8);
+}
+
+void get_nice_prgname(char* dest, char* src)
+{
+  char* pdest = dest;
+  char* psrc = src;
+  while (*psrc != '.' && *psrc != '\0')
+  {
+    *pdest = toupper(*psrc);
+    pdest++;
+    psrc++;
+  }
+  *pdest = '\0';
+}
+
+void get_nice_d81name(char* dest, char* src)
+{
+  get_nice_prgname(dest, src);
+
+  strcat(dest, ".D81");
+}
+
+int calc_offset(int track, int sector, int offset)
+{
+  return (track-1)*(256*40) + sector*256 + offset;
+}
+
+void mark_sector_used(char* bamentry, int sector)
+{
+  int offs = sector >> 3;
+  int bitloc = sector & 0x0f;
+  bamentry[1 + offs] &= ~bitloc;
+}
+
+int calc_sectors_free(char* bamentry)
+{
+  int cnt = 0;
+  for (int k = 1; k < 6; k++)
+  {
+    int byteval = bamentry[k];
+    for (int z = 0; z < 8; z++)
+    {
+      if (byteval & (1<<z))
+        cnt++;
+    }
+  }
+  return cnt;
+}
+
+void update_bam(int track, int sector)
+{
+  int offs;
+  if (track <=40)
+    offs = calc_offset(40, 1, 0x10) + (track-1)*0x06; // 6 bytes per track BAM entry
+  else
+    offs = calc_offset(40, 2, 0x10) + (track-41)*0x06; // 6 bytes per track BAM entry
+
+  // first bam sector is at t/s = 40/1, 2nd bam is at t/s = 40/2
+  char* bamentry = &data[offs];
+
+  mark_sector_used(bamentry, sector);
+  bamentry[0x00] = calc_sectors_free(bamentry); // number of free sectors on the track
+}
+
+void update_tsptr(int track, int sector, int t, int s)
+{
+  char* dest = &data[(track-1)*(256*40) + sector*256];
+  dest[0] = t;
+  dest[1] = s;
+}
+
+void write_sector(int track, int sector, char* chunk)
+{
+  char* dest = &data[(track-1)*(256*40) + sector*256];
+  memcpy(dest, chunk, 256);
+
+  // update bam?
+  update_bam(track, sector);
+}
+
+void add_prg(char* fname)
+{
+  // load the prg
+  FILE *f = fopen(fname, "rb");
+  char prgname[256];
+  get_nice_prgname(prgname, fname);
+  char chunk[256] = { 0 };
+
+  int starttrack = 1;
+  int startsector = 0;
+  int curtrack = starttrack;
+  int cursector = startsector;
+  int prevtrack = 0;
+  int prevsector = 0;
+
+  int bytes;
+  int sectorcnt = 0;
+  while ((bytes = fread(chunk+2, 1, 254, f)) != 0)
+  {
+    if (sectorcnt != 0)
+    {
+      update_tsptr(prevtrack, prevsector, curtrack, cursector);
+    }
+    chunk[0] = 0x00;  // assume this is the last chunk
+    chunk[1] = 0xff;  // (can overwrite it later)
+    write_sector(curtrack, cursector, chunk);
+    prevtrack = curtrack;
+    prevsector = cursector;
+    sectorcnt++;
+    memset(chunk, 0, 256);
+    cursector++;
+    if (cursector >= 40)
+    {
+      cursector = 0;
+      curtrack++;
+    }
+  }
+
+  write_direntry(prgname, starttrack, startsector, sectorcnt);
+
+  fclose(f);
+}
+
+void save_d81(char* fname)
+{
+  FILE *f = fopen(fname, "wb");
+  fwrite(data, 1, 819200, f);
+  fclose(f);
+}
+
+char* create_d81_for_prg(char* prgfname)
+{
+  static char d81name[256];
+  memset(data, 0, 819200);
+  write_header("PRG WRAPPER", "GI");
+  add_prg(prgfname);
+
+  get_nice_d81name(d81name, prgfname);
+  printf("Wrapping \"%s\" into \"%s\"...\n", prgfname, d81name);
+  save_d81(d81name);
+  return d81name;
+}
+
+void main(void)
+{
+  create_d81_for_prg("momo.prg");
+}

--- a/src/tools/diskman.c
+++ b/src/tools/diskman.c
@@ -6,21 +6,19 @@ char data[819200];
 
 void write_tso_byte(int track, int sector, int offset, int val)
 {
-  data[(track-1)*(256*40) + sector*256 + offset] = val;
+  data[(track - 1) * (256 * 40) + sector * 256 + offset] = val;
 }
 
 void write_tso_str(int track, int sector, int offset, char* str, int maxlen)
 {
   char* pstr = str;
-  for (int k = 0; k < maxlen; k++)
-  {
+  for (int k = 0; k < maxlen; k++) {
     int val = 0xa0; // assume padding byte
-    if (*pstr != '\0')
-    {
+    if (*pstr != '\0') {
       val = *pstr;
       pstr++;
     }
-    write_tso_byte(track, sector, offset+k, val);
+    write_tso_byte(track, sector, offset + k, val);
   }
 }
 
@@ -30,10 +28,10 @@ void write_header(char* disk_name, char* disk_id)
   write_tso_byte(40, 0, 0x01, 3);
   write_tso_byte(40, 0, 0x02, 0x44); // Disk DOS version type 'D' = 1581
   write_tso_byte(40, 0, 0x03, 0);
-  write_tso_str (40, 0, 0x04, disk_name, 16);
+  write_tso_str(40, 0, 0x04, disk_name, 16);
   write_tso_byte(40, 0, 0x14, 0xA0);
   write_tso_byte(40, 0, 0x15, 0xA0);
-  write_tso_str (40, 0, 0x16, disk_id, 2);
+  write_tso_str(40, 0, 0x16, disk_id, 2);
   write_tso_byte(40, 0, 0x18, 0xA0);
   write_tso_byte(40, 0, 0x19, '3');
   write_tso_byte(40, 0, 0x1A, 'D');
@@ -41,27 +39,27 @@ void write_header(char* disk_name, char* disk_id)
   write_tso_byte(40, 0, 0x1C, 0xA0);
 
   // some BAM initialisation too
-  write_tso_byte(40, 1, 0x00, 40);  // next bam t/s
+  write_tso_byte(40, 1, 0x00, 40); // next bam t/s
   write_tso_byte(40, 1, 0x01, 2);
   write_tso_byte(40, 1, 0x02, 'D');
   write_tso_byte(40, 1, 0x03, 0xBB);
-  write_tso_str (40, 1, 0x04, disk_id, 2);
+  write_tso_str(40, 1, 0x04, disk_id, 2);
   write_tso_byte(40, 1, 0x06, 0xC0); // verify on, check header crc
-  write_tso_byte(40, 1, 0x07, 0x00);  // auto-bootloader flag?
+  write_tso_byte(40, 1, 0x07, 0x00); // auto-bootloader flag?
   // initialise bam entries for tracks (set all sectors as empty)
   for (int k = 0; k < 40; k++)
-    write_tso_str(40, 1, 0x10 + k*6, "\x28\xff\xff\xff\xff\xff", 6);
+    write_tso_str(40, 1, 0x10 + k * 6, "\x28\xff\xff\xff\xff\xff", 6);
 
-  write_tso_byte(40, 2, 0x00, 0x00);  // next bam t/s (0x00 0xff is last one)
+  write_tso_byte(40, 2, 0x00, 0x00); // next bam t/s (0x00 0xff is last one)
   write_tso_byte(40, 2, 0x01, 0xff);
   write_tso_byte(40, 2, 0x02, 'D');
   write_tso_byte(40, 2, 0x03, 0xBB);
-  write_tso_str (40, 2, 0x04, disk_id, 2);
+  write_tso_str(40, 2, 0x04, disk_id, 2);
   write_tso_byte(40, 2, 0x06, 0xC0); // verify on, check header crc
-  write_tso_byte(40, 2, 0x07, 0x00);  // auto-bootloader flag?
+  write_tso_byte(40, 2, 0x07, 0x00); // auto-bootloader flag?
   // initialise bam entries for tracks (set all sectors as empty)
   for (int k = 0; k < 40; k++)
-    write_tso_str(40, 2, 0x10 + k*6, "\x28\xff\xff\xff\xff\xff", 6);
+    write_tso_str(40, 2, 0x10 + k * 6, "\x28\xff\xff\xff\xff\xff", 6);
 }
 
 #define FTYPE_DEL 0
@@ -70,7 +68,7 @@ void write_header(char* disk_name, char* disk_id)
 #define FTYPE_USR 3
 #define FTYPE_REL 4
 #define FTYPE_CBM 5
-#define FTYPE_CLOSEDFLAG  0x80
+#define FTYPE_CLOSEDFLAG 0x80
 
 void write_direntry(char* prgname, int firsttrack, int firstsector, int sectorcnt)
 {
@@ -79,7 +77,7 @@ void write_direntry(char* prgname, int firsttrack, int firstsector, int sectorcn
   write_tso_byte(40, 3, 0x02, FTYPE_PRG | FTYPE_CLOSEDFLAG);
   write_tso_byte(40, 3, 0x03, firsttrack);
   write_tso_byte(40, 3, 0x04, firstsector);
-  write_tso_str (40, 3, 0x05, prgname, 16);
+  write_tso_str(40, 3, 0x05, prgname, 16);
   write_tso_byte(40, 3, 0x15, 0x00);
   write_tso_byte(40, 3, 0x16, 0x00);
   write_tso_byte(40, 3, 0x17, 0x00);
@@ -91,8 +89,7 @@ void get_nice_prgname(char* dest, char* src)
 {
   char* pdest = dest;
   char* psrc = src;
-  while (*psrc != '.' && *psrc != '\0')
-  {
+  while (*psrc != '.' && *psrc != '\0') {
     *pdest = toupper(*psrc);
     pdest++;
     psrc++;
@@ -109,7 +106,7 @@ void get_nice_d81name(char* dest, char* src)
 
 int calc_offset(int track, int sector, int offset)
 {
-  return (track-1)*(256*40) + sector*256 + offset;
+  return (track - 1) * (256 * 40) + sector * 256 + offset;
 }
 
 void mark_sector_used(char* bamentry, int sector)
@@ -122,12 +119,10 @@ void mark_sector_used(char* bamentry, int sector)
 int calc_sectors_free(char* bamentry)
 {
   int cnt = 0;
-  for (int k = 1; k < 6; k++)
-  {
+  for (int k = 1; k < 6; k++) {
     int byteval = bamentry[k];
-    for (int z = 0; z < 8; z++)
-    {
-      if (byteval & (1<<z))
+    for (int z = 0; z < 8; z++) {
+      if (byteval & (1 << z))
         cnt++;
     }
   }
@@ -137,10 +132,10 @@ int calc_sectors_free(char* bamentry)
 void update_bam(int track, int sector)
 {
   int offs;
-  if (track <=40)
-    offs = calc_offset(40, 1, 0x10) + (track-1)*0x06; // 6 bytes per track BAM entry
+  if (track <= 40)
+    offs = calc_offset(40, 1, 0x10) + (track - 1) * 0x06; // 6 bytes per track BAM entry
   else
-    offs = calc_offset(40, 2, 0x10) + (track-41)*0x06; // 6 bytes per track BAM entry
+    offs = calc_offset(40, 2, 0x10) + (track - 41) * 0x06; // 6 bytes per track BAM entry
 
   // first bam sector is at t/s = 40/1, 2nd bam is at t/s = 40/2
   char* bamentry = &data[offs];
@@ -151,14 +146,14 @@ void update_bam(int track, int sector)
 
 void update_tsptr(int track, int sector, int t, int s)
 {
-  char* dest = &data[(track-1)*(256*40) + sector*256];
+  char* dest = &data[(track - 1) * (256 * 40) + sector * 256];
   dest[0] = t;
   dest[1] = s;
 }
 
 static void write_sector(int track, int sector, char* chunk)
 {
-  char* dest = &data[(track-1)*(256*40) + sector*256];
+  char* dest = &data[(track - 1) * (256 * 40) + sector * 256];
   memcpy(dest, chunk, 256);
 
   // update bam?
@@ -168,7 +163,7 @@ static void write_sector(int track, int sector, char* chunk)
 void add_prg(char* fname)
 {
   // load the prg
-  FILE *f = fopen(fname, "rb");
+  FILE* f = fopen(fname, "rb");
   char prgname[256];
   get_nice_prgname(prgname, fname);
   char chunk[256] = { 0 };
@@ -182,22 +177,19 @@ void add_prg(char* fname)
 
   int bytes;
   int sectorcnt = 0;
-  while ((bytes = fread(chunk+2, 1, 254, f)) != 0)
-  {
-    if (sectorcnt != 0)
-    {
+  while ((bytes = fread(chunk + 2, 1, 254, f)) != 0) {
+    if (sectorcnt != 0) {
       update_tsptr(prevtrack, prevsector, curtrack, cursector);
     }
-    chunk[0] = 0x00;  // assume this is the last chunk
-    chunk[1] = 0xff;  // (can overwrite it later)
+    chunk[0] = 0x00; // assume this is the last chunk
+    chunk[1] = 0xff; // (can overwrite it later)
     write_sector(curtrack, cursector, chunk);
     prevtrack = curtrack;
     prevsector = cursector;
     sectorcnt++;
     memset(chunk, 0, 256);
     cursector++;
-    if (cursector >= 40)
-    {
+    if (cursector >= 40) {
       cursector = 0;
       curtrack++;
     }
@@ -210,7 +202,7 @@ void add_prg(char* fname)
 
 void save_d81(char* fname)
 {
-  FILE *f = fopen(fname, "wb");
+  FILE* f = fopen(fname, "wb");
   fwrite(data, 1, 819200, f);
   fclose(f);
 }

--- a/src/tools/diskman.h
+++ b/src/tools/diskman.h
@@ -1,0 +1,6 @@
+#ifndef DISKMAN_H
+#define DISKMAN_H
+
+char* create_d81_for_prg(char* prgfname);
+
+#endif // DISKMAN_H

--- a/src/tools/filehost.c
+++ b/src/tools/filehost.c
@@ -1,0 +1,231 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "m65common.h"
+
+#define FINISHED -1
+
+int check_char(char actual_c, char expected_c)
+{
+  if (expected_c != actual_c)
+  {
+    printf("ERROR: Expected '%c' char, got '%c' instead!\n", expected_c, actual_c);
+    exit(1);
+  }
+  return 1;
+}
+
+int check_char_startflag(char actual_c, char expected_c, int* startflag)
+{
+  if (!*startflag)
+  {
+    check_char(actual_c, expected_c);
+    *startflag = 1;
+    return 1;
+  }
+  return 0;
+}
+
+typedef struct file_info
+{
+  char title[256];
+  char os[256];
+  char filename[256];
+  char location[256];
+  char author[64];
+} tfile_info;
+
+typedef struct list_item
+{
+  void* next;
+  void* cur;
+} tlist_item;
+
+tlist_item lst_finfos = { 0 };
+
+void assess_key_val(tfile_info *finfo, char* key, char* val)
+{
+  if (strcmp(key, "title") == 0)
+    strcpy(finfo->title, val);
+  if (strcmp(key, "os") == 0)
+    strcpy(finfo->os, val);
+  if (strcmp(key, "filename") == 0)
+    strcpy(finfo->filename, val);
+  if (strcmp(key, "location") == 0)
+    strcpy(finfo->location, val);
+  if (strcmp(key, "author") == 0)
+    strcpy(finfo->author, val);
+}
+
+int read_in_key_or_value_string(tfile_info* finfo, char c, int *iskey, int *quotestart)
+{
+  static char tmp[4096];
+  static int tmplen = 0;
+  static char key[4096];
+  static char val[4096];
+
+  // read in a key or a value string
+  if (c != '"')
+  {
+    tmp[tmplen] = c;
+    tmplen++;
+  }
+  else
+  {
+    *quotestart = 0;
+    tmp[tmplen] = '\0';
+    tmplen = 0;
+    if (*iskey)
+    {
+      strcpy(key, tmp);
+      *iskey = 0;
+    }
+    else
+    {
+      strcpy(val, tmp);
+      *iskey = 1;
+      assess_key_val(finfo, key, val);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+void add_to_list(tfile_info* finfo)
+{
+  tlist_item* ptr = &lst_finfos;
+  while (ptr->cur != NULL)
+  {
+    if (ptr->next)
+    {
+      ptr = ptr->next;
+    }
+    else
+    {
+      ptr->next = malloc(sizeof(tlist_item));
+      ptr = ptr->next;
+      memset(ptr, 0, sizeof(tlist_item));
+    }
+  }
+
+  ptr->cur = malloc(sizeof(tfile_info));
+  memcpy(ptr->cur, finfo, sizeof(tfile_info));
+}
+
+int read_rows(char* str, int strcnt)
+{
+  static int squarebrackstart = 0;
+  static int curlbrackstart = 0;
+  static int quotestart = 0;
+  static int valquotestart = 0;
+  static tfile_info finfo = { 0 };
+
+  static int iskey = 1;
+
+  for (int k = 0; k < strcnt; k++)
+  {
+    char c = str[k];
+
+    // skip header bytes and wait for '['
+    if (!squarebrackstart)
+    {
+      if (c != '[')
+        continue;
+      
+      squarebrackstart = 1;
+      continue;
+    }
+
+    if (!curlbrackstart)
+    {
+      // skip any ',' preceding '{'
+      if (c == ',')
+      continue;
+
+      // found the ']' char? (no more '{' expected)
+      if (c == ']')
+      {
+        squarebrackstart = 0;
+        return 0;
+      }
+    }
+
+    if (check_char_startflag(c, '{', &curlbrackstart))
+    {
+      memset(&finfo, 0, sizeof(tfile_info));
+      continue;
+    }
+
+    if (!quotestart)
+    {
+      if (!iskey) // are we expecting a value next?
+      {
+        if (c == ':')
+          continue;
+      }
+      else
+      {
+        // are we expecting another
+        if (c == ',')
+          continue;
+
+        // are we expecting an end of curly-bracket?
+        if (c == '}')
+        {
+          if (finfo.author[0] != '\0' && strcmp(finfo.os, " MEGA65") == 0)
+          {
+            add_to_list(&finfo);
+            memset(&finfo, 0, sizeof(tfile_info));
+          }
+          curlbrackstart = 0;
+          continue;
+        }
+      }
+    }
+
+    if (check_char_startflag(c, '"', &quotestart))
+      continue;
+
+    if (read_in_key_or_value_string(&finfo, c, &iskey, &quotestart))
+    {
+    }
+  }
+  return 1;
+}
+
+void print_items(void)
+{
+  tlist_item *ptr = &lst_finfos;
+  while (ptr != NULL)
+  {
+    tfile_info *pfinfo = (tfile_info*)ptr->cur;
+    printf("title: %s\nfilename: %s\nlocation: %s\nauthor: %s\n\n",
+        pfinfo->title, pfinfo->filename, pfinfo->location, pfinfo->author);
+
+    ptr = ptr->next;
+  }
+}
+
+void read_filehost_struct(void)
+{
+  char str[4096];
+  PORT_TYPE fd = open_tcp_port("tcp#files.mega65.org:80");
+  do_write(fd, "GET /php/readfilespublic.php HTTP/1.1\r\n");
+  do_write(fd, "Host: files.mega65.org\r\n\r\n");
+
+  do_usleep(100000);
+
+  int count = 0, total = 0;
+  while( (count = do_read(fd, str, 4096)) != 0 || total == 0)
+  {
+    if (!read_rows(str, count))
+      break;
+  }
+
+  print_items();
+}
+
+void main(void)
+{
+  read_filehost_struct();
+}

--- a/src/tools/filehost.c
+++ b/src/tools/filehost.c
@@ -137,7 +137,6 @@ int read_rows(char* str, int strcnt)
   static int squarebrackstart = 0;
   static int curlbrackstart = 0;
   static int quotestart = 0;
-  static int valquotestart = 0;
   static tfile_info finfo = { 0 };
 
   static int iskey = 1;
@@ -328,7 +327,10 @@ void strupper(char* dest, char* src)
 char* download_file_from_filehost(int fileidx)
 {
   char* path;
-  char fname[256];
+  static char fname[256];
+  char* retfname = NULL;
+
+  fname[0] = '\0';
   
   tlist_item *ptr = &lst_finfos;
   int cnt = 1;
@@ -403,6 +405,7 @@ char* download_file_from_filehost(int fileidx)
         if (total == content_length)
         {
           printf("Download of \"%s\" file complete\n", fname);
+          retfname = fname;
           break;
         }
       }
@@ -414,10 +417,13 @@ char* download_file_from_filehost(int fileidx)
   }
 
   close_tcp_port(fd);
+  return retfname;
 }
 
+/*
 void main(void)
 {
   read_filehost_struct();
   download_file_from_filehost(25);
 }
+*/

--- a/src/tools/filehost.c
+++ b/src/tools/filehost.c
@@ -353,7 +353,7 @@ char* download_file_from_filehost(int fileidx)
   path = pfi->location;
   strupper(fname, pfi->filename);
 
-  printf("path = %s, fname = %s\n", path, fname);
+  printf("Downloading \"%s\"...\n", fname);
 
   char str[4096];
   PORT_TYPE fd = open_tcp_port("tcp#files.mega65.org:80");
@@ -405,6 +405,7 @@ char* download_file_from_filehost(int fileidx)
         if (total == content_length)
         {
           printf("Download of \"%s\" file complete\n", fname);
+          fclose(f);
           retfname = fname;
           break;
         }

--- a/src/tools/filehost.c
+++ b/src/tools/filehost.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
+#include <ctype.h>
 #include "m65common.h"
 
 #define FINISHED -1

--- a/src/tools/filehost.c
+++ b/src/tools/filehost.c
@@ -223,9 +223,140 @@ void read_filehost_struct(void)
   }
 
   print_items();
+
+  close_tcp_port(fd);
+}
+
+int check_file_start(char c)
+{
+  static char *term = "\r\n\r\n";
+  static int termidx = 0;
+
+  if (c == term[termidx])
+  {
+    termidx++;
+    if (term[termidx] == '\0')
+    {
+      termidx = 0;
+      return 1;
+    }
+  }
+  else
+    termidx = 0;
+
+  return 0;
+}
+
+void check_content_length(char c, int* content_length)
+{
+  static char *term = "Content-Length: ";
+  static int termmatch = 0;
+  static int termidx = 0;
+  static char value[128] = "";
+  static int valueidx = 0;
+
+  if (!termmatch)
+  {
+    if (c == term[termidx])
+    {
+      termidx++;
+      if (term[termidx] == '\0')
+      {
+        termmatch = 1;
+        termidx = 0;
+      }
+    }
+    else
+      termidx = 0;
+  }
+  // checking for value now
+  else
+  {
+    if (c == '\r' || c == '\n')
+    {
+      // We reached the end of the value, now parse it
+      value[valueidx] = '\0';
+      *content_length = atoi(value);
+      // reset vars for next time
+      termmatch = 0;
+      termidx = 0;
+      valueidx = 0;
+    }
+    else
+    {
+      value[valueidx] = c;
+      valueidx++;
+    }
+  }
+}
+
+void download_file(char *path, char *fname)
+{
+  char str[4096];
+  PORT_TYPE fd = open_tcp_port("tcp#files.mega65.org:80");
+  sprintf(str, "GET /php/%s HTTP/1.1\r\n", path);
+  do_write(fd, str);
+  do_write(fd, "Host: files.mega65.org\r\n\r\n");
+
+  do_usleep(100000);
+
+  int count = 0, total = 0;
+  int content_length = 0;
+  int file_started = 0;
+  FILE *f = NULL;
+  while(content_length == 0 || total != content_length)
+  {
+    count = do_read(fd, str, 4096);
+    if (count == 0)
+    {
+      do_usleep(10000);
+      continue;
+    }
+
+    // printf("reading %d bytes...\n", count);
+    for (int k = 0; k < count; k++)
+    {
+      char c = str[k];
+      if (!content_length)
+      {
+        check_content_length(c, &content_length);
+        if (!content_length)
+          continue;
+        printf("content_length=%d\n", content_length);
+      }
+
+      if (!file_started)
+      {
+        // wait for header to finish
+        if (check_file_start(c))
+        {
+          file_started = 1;
+          f = fopen(fname, "wb");
+        }
+      }
+      else
+      {
+        // now start saving out bytes
+        fputc(c, f);
+        total++;
+        if (total == content_length)
+        {
+          printf("Download of file complete\n");
+          break;
+        }
+      }
+    }
+    if (content_length != 0 && total == content_length)
+    {
+      break;
+    }
+  }
+
+  close_tcp_port(fd);
 }
 
 void main(void)
 {
-  read_filehost_struct();
+  // read_filehost_struct();
+  download_file("../files/c/camelot-1536dots_a5uS3h.prg", "camelot.prg");
 }

--- a/src/tools/filehost.c
+++ b/src/tools/filehost.c
@@ -191,7 +191,7 @@ int read_rows(char* str, int strcnt)
         // are we expecting an end of curly-bracket?
         if (c == '}')
         {
-          if (finfo.author[0] != '\0' && strstr(finfo.os, " MEGA65") != NULL)
+          if (finfo.author[0] != '\0' && strstr(finfo.os, "MEGA65") != NULL)
           {
             add_to_list(&finfo);
             memset(&finfo, 0, sizeof(tfile_info));

--- a/src/tools/filehost.c
+++ b/src/tools/filehost.c
@@ -312,10 +312,23 @@ void check_content_length(char c, int* content_length)
   }
 }
 
+void strupper(char* dest, char* src)
+{
+  char* psrc = src;
+  char* pdest = dest;
+  while (*psrc != '\0')
+  {
+    *pdest = toupper(*psrc);
+    psrc++;
+    pdest++;
+  }
+  *pdest = '\0';
+}
+
 char* download_file_from_filehost(int fileidx)
 {
   char* path;
-  char* fname;
+  char fname[256];
   
   tlist_item *ptr = &lst_finfos;
   int cnt = 1;
@@ -336,7 +349,7 @@ char* download_file_from_filehost(int fileidx)
   tfile_info *pfi = (tfile_info*)ptr->cur;
 
   path = pfi->location;
-  fname = pfi->filename;
+  strupper(fname, pfi->filename);
 
   printf("path = %s, fname = %s\n", path, fname);
 

--- a/src/tools/filehost.c
+++ b/src/tools/filehost.c
@@ -7,8 +7,7 @@
 
 int check_char(char actual_c, char expected_c)
 {
-  if (expected_c != actual_c)
-  {
+  if (expected_c != actual_c) {
     printf("ERROR: Expected '%c' char, got '%c' instead!\n", expected_c, actual_c);
     exit(1);
   }
@@ -17,8 +16,7 @@ int check_char(char actual_c, char expected_c)
 
 int check_char_startflag(char actual_c, char expected_c, int* startflag)
 {
-  if (!*startflag)
-  {
+  if (!*startflag) {
     check_char(actual_c, expected_c);
     *startflag = 1;
     return 1;
@@ -26,8 +24,7 @@ int check_char_startflag(char actual_c, char expected_c, int* startflag)
   return 0;
 }
 
-typedef struct file_info
-{
+typedef struct file_info {
   char title[256];
   char os[256];
   char filename[256];
@@ -35,8 +32,7 @@ typedef struct file_info
   char author[64];
 } tfile_info;
 
-typedef struct list_item
-{
+typedef struct list_item {
   void* next;
   void* cur;
 } tlist_item;
@@ -48,10 +44,8 @@ void clean_copy(char* dest, char* src)
   char* sptr = src;
   char* dptr = dest;
 
-  while (*sptr != '\0')
-  {
-    if (*sptr == '\\')
-    {
+  while (*sptr != '\0') {
+    if (*sptr == '\\') {
       sptr++;
       continue;
     }
@@ -63,7 +57,7 @@ void clean_copy(char* dest, char* src)
   *dptr = '\0';
 }
 
-void assess_key_val(tfile_info *finfo, char* key, char* val)
+void assess_key_val(tfile_info* finfo, char* key, char* val)
 {
   if (strcmp(key, "title") == 0)
     strcpy(finfo->title, val);
@@ -77,7 +71,7 @@ void assess_key_val(tfile_info *finfo, char* key, char* val)
     strcpy(finfo->author, val);
 }
 
-int read_in_key_or_value_string(tfile_info* finfo, char c, int *iskey, int *quotestart)
+int read_in_key_or_value_string(tfile_info* finfo, char c, int* iskey, int* quotestart)
 {
   static char tmp[4096];
   static int tmplen = 0;
@@ -85,23 +79,19 @@ int read_in_key_or_value_string(tfile_info* finfo, char c, int *iskey, int *quot
   static char val[4096];
 
   // read in a key or a value string
-  if (c != '"')
-  {
+  if (c != '"') {
     tmp[tmplen] = c;
     tmplen++;
   }
-  else
-  {
+  else {
     *quotestart = 0;
     tmp[tmplen] = '\0';
     tmplen = 0;
-    if (*iskey)
-    {
+    if (*iskey) {
       strcpy(key, tmp);
       *iskey = 0;
     }
-    else
-    {
+    else {
       strcpy(val, tmp);
       *iskey = 1;
       assess_key_val(finfo, key, val);
@@ -114,14 +104,11 @@ int read_in_key_or_value_string(tfile_info* finfo, char c, int *iskey, int *quot
 void add_to_list(tfile_info* finfo)
 {
   tlist_item* ptr = &lst_finfos;
-  while (ptr->cur != NULL)
-  {
-    if (ptr->next)
-    {
+  while (ptr->cur != NULL) {
+    if (ptr->next) {
       ptr = (tlist_item*)ptr->next;
     }
-    else
-    {
+    else {
       ptr->next = malloc(sizeof(tlist_item));
       ptr = (tlist_item*)ptr->next;
       memset(ptr, 0, sizeof(tlist_item));
@@ -141,58 +128,49 @@ int read_rows(char* str, int strcnt)
 
   static int iskey = 1;
 
-  for (int k = 0; k < strcnt; k++)
-  {
+  for (int k = 0; k < strcnt; k++) {
     char c = str[k];
 
     // skip header bytes and wait for '['
-    if (!squarebrackstart)
-    {
+    if (!squarebrackstart) {
       if (c != '[')
         continue;
-      
+
       squarebrackstart = 1;
       continue;
     }
 
-    if (!curlbrackstart)
-    {
+    if (!curlbrackstart) {
       // skip any ',' preceding '{'
       if (c == ',')
-      continue;
+        continue;
 
       // found the ']' char? (no more '{' expected)
-      if (c == ']')
-      {
+      if (c == ']') {
         squarebrackstart = 0;
         return 0;
       }
     }
 
-    if (check_char_startflag(c, '{', &curlbrackstart))
-    {
+    if (check_char_startflag(c, '{', &curlbrackstart)) {
       memset(&finfo, 0, sizeof(tfile_info));
       continue;
     }
 
-    if (!quotestart)
-    {
+    if (!quotestart) {
       if (!iskey) // are we expecting a value next?
       {
         if (c == ':')
           continue;
       }
-      else
-      {
+      else {
         // are we expecting another
         if (c == ',')
           continue;
 
         // are we expecting an end of curly-bracket?
-        if (c == '}')
-        {
-          if (finfo.author[0] != '\0' && strstr(finfo.os, "MEGA65") != NULL)
-          {
+        if (c == '}') {
+          if (finfo.author[0] != '\0' && strstr(finfo.os, "MEGA65") != NULL) {
             add_to_list(&finfo);
             memset(&finfo, 0, sizeof(tfile_info));
           }
@@ -205,9 +183,7 @@ int read_rows(char* str, int strcnt)
     if (check_char_startflag(c, '"', &quotestart))
       continue;
 
-    if (read_in_key_or_value_string(&finfo, c, &iskey, &quotestart))
-    {
-    }
+    if (read_in_key_or_value_string(&finfo, c, &iskey, &quotestart)) { }
   }
   return 1;
 }
@@ -215,12 +191,10 @@ int read_rows(char* str, int strcnt)
 void print_items(void)
 {
   int cnt = 1;
-  tlist_item *ptr = &lst_finfos;
-  while (ptr != NULL)
-  {
-    tfile_info *pfinfo = (tfile_info*)ptr->cur;
-    printf("%d: %s - \"%s\" - author: %s\n",
-        cnt, pfinfo->title, pfinfo->filename, pfinfo->author);
+  tlist_item* ptr = &lst_finfos;
+  while (ptr != NULL) {
+    tfile_info* pfinfo = (tfile_info*)ptr->cur;
+    printf("%d: %s - \"%s\" - author: %s\n", cnt, pfinfo->title, pfinfo->filename, pfinfo->author);
 
     ptr = (tlist_item*)ptr->next;
     cnt++;
@@ -241,13 +215,12 @@ void log_in_and_get_cookie(char* username, char* password)
   do_write(fd, "Content-Type: application/x-www-form-urlencoded; charset=UTF-8\r\n");
   do_write(fd, "X-Requested-With: XMLHttpRequest\r\n");
   sprintf(str, "Content-Length: %d\r\n\r\n", (int)strlen(data));
-  do_write(fd, str); 
+  do_write(fd, str);
   do_write(fd, data);
 
   int count = 0, total = 0;
   data[0] = 0;
-  while( (count = do_read(fd, str, 4096)) != 0 || total == 0)
-  {
+  while ((count = do_read(fd, str, 4096)) != 0 || total == 0) {
     if (count == 0)
       continue;
 
@@ -259,13 +232,11 @@ void log_in_and_get_cookie(char* username, char* password)
   cookies[0] = 0;
   int ckptr = 0;
   char* cookie_field = "Set-Cookie:";
-  do
-  {
+  do {
     if (strncmp(ptr, cookie_field, strlen(cookie_field)) == 0) {
       ptr += strlen(cookie_field);
       int k = 0;
-      do
-      {
+      do {
         cookies[ckptr] = ptr[k];
         k++;
         ckptr++;
@@ -276,7 +247,7 @@ void log_in_and_get_cookie(char* username, char* password)
     }
     ptr = strtok(NULL, "\n");
   } while (ptr != NULL);
-  
+
   close_tcp_port(fd);
 }
 
@@ -287,7 +258,7 @@ void read_filehost_struct(void)
   do_write(fd, "GET /php/readfilespublic.php HTTP/1.1\r\n");
   do_write(fd, "Host: files.mega65.org\r\n");
   if (cookies[0] != '\0') {
-    cookies[strlen(cookies)-1]='\0'; //remove last ';'
+    cookies[strlen(cookies) - 1] = '\0'; // remove last ';'
     sprintf(str, "Cookie:%s\r\n", cookies);
     do_write(fd, str);
   }
@@ -296,8 +267,7 @@ void read_filehost_struct(void)
   do_usleep(100000);
 
   int count = 0, total = 0;
-  while( (count = do_read(fd, str, 4096)) != 0 || total == 0)
-  {
+  while ((count = do_read(fd, str, 4096)) != 0 || total == 0) {
     if (!read_rows(str, count))
       break;
   }
@@ -309,14 +279,12 @@ void read_filehost_struct(void)
 
 int check_file_start(char c)
 {
-  static char *term = "\r\n\r\n";
+  static char* term = "\r\n\r\n";
   static int termidx = 0;
 
-  if (c == term[termidx])
-  {
+  if (c == term[termidx]) {
     termidx++;
-    if (term[termidx] == '\0')
-    {
+    if (term[termidx] == '\0') {
       termidx = 0;
       return 1;
     }
@@ -329,19 +297,16 @@ int check_file_start(char c)
 
 void check_content_length(char c, int* content_length)
 {
-  static char *term = "Content-Length: ";
+  static char* term = "Content-Length: ";
   static int termmatch = 0;
   static int termidx = 0;
   static char value[128] = "";
   static int valueidx = 0;
 
-  if (!termmatch)
-  {
-    if (c == term[termidx])
-    {
+  if (!termmatch) {
+    if (c == term[termidx]) {
       termidx++;
-      if (term[termidx] == '\0')
-      {
+      if (term[termidx] == '\0') {
         termmatch = 1;
         termidx = 0;
       }
@@ -350,10 +315,8 @@ void check_content_length(char c, int* content_length)
       termidx = 0;
   }
   // checking for value now
-  else
-  {
-    if (c == '\r' || c == '\n')
-    {
+  else {
+    if (c == '\r' || c == '\n') {
       // We reached the end of the value, now parse it
       value[valueidx] = '\0';
       *content_length = atoi(value);
@@ -362,8 +325,7 @@ void check_content_length(char c, int* content_length)
       termidx = 0;
       valueidx = 0;
     }
-    else
-    {
+    else {
       value[valueidx] = c;
       valueidx++;
     }
@@ -374,8 +336,7 @@ void strupper(char* dest, char* src)
 {
   char* psrc = src;
   char* pdest = dest;
-  while (*psrc != '\0')
-  {
+  while (*psrc != '\0') {
     *pdest = toupper(*psrc);
     psrc++;
     pdest++;
@@ -390,24 +351,22 @@ char* download_file_from_filehost(int fileidx)
   char* retfname = NULL;
 
   fname[0] = '\0';
-  
-  tlist_item *ptr = &lst_finfos;
+
+  tlist_item* ptr = &lst_finfos;
   int cnt = 1;
-  while (ptr != NULL)
-  {
+  while (ptr != NULL) {
     if (fileidx == cnt)
       break;
     ptr = (tlist_item*)ptr->next;
     cnt++;
   }
 
-  if (fileidx != cnt)
-  {
+  if (fileidx != cnt) {
     printf("ERROR: Invalid file index\n");
     return NULL;
   }
 
-  tfile_info *pfi = (tfile_info*)ptr->cur;
+  tfile_info* pfi = (tfile_info*)ptr->cur;
 
   path = pfi->location;
   strupper(fname, pfi->filename);
@@ -425,44 +384,36 @@ char* download_file_from_filehost(int fileidx)
   int count = 0, total = 0;
   int content_length = 0;
   int file_started = 0;
-  FILE *f = NULL;
-  while(content_length == 0 || total != content_length)
-  {
+  FILE* f = NULL;
+  while (content_length == 0 || total != content_length) {
     count = do_read(fd, str, 4096);
-    if (count == 0)
-    {
+    if (count == 0) {
       do_usleep(10000);
       continue;
     }
 
     // printf("reading %d bytes...\n", count);
-    for (int k = 0; k < count; k++)
-    {
+    for (int k = 0; k < count; k++) {
       char c = str[k];
-      if (!content_length)
-      {
+      if (!content_length) {
         check_content_length(c, &content_length);
         if (!content_length)
           continue;
         printf("content_length=%d\n", content_length);
       }
 
-      if (!file_started)
-      {
+      if (!file_started) {
         // wait for header to finish
-        if (check_file_start(c))
-        {
+        if (check_file_start(c)) {
           file_started = 1;
           f = fopen(fname, "wb");
         }
       }
-      else
-      {
+      else {
         // now start saving out bytes
         fputc(c, f);
         total++;
-        if (total == content_length)
-        {
+        if (total == content_length) {
           printf("Download of \"%s\" file complete\n", fname);
           fclose(f);
           retfname = fname;
@@ -470,8 +421,7 @@ char* download_file_from_filehost(int fileidx)
         }
       }
     }
-    if (content_length != 0 && total == content_length)
-    {
+    if (content_length != 0 && total == content_length) {
       break;
     }
   }

--- a/src/tools/filehost.c
+++ b/src/tools/filehost.c
@@ -118,12 +118,12 @@ void add_to_list(tfile_info* finfo)
   {
     if (ptr->next)
     {
-      ptr = ptr->next;
+      ptr = (tlist_item*)ptr->next;
     }
     else
     {
       ptr->next = malloc(sizeof(tlist_item));
-      ptr = ptr->next;
+      ptr = (tlist_item*)ptr->next;
       memset(ptr, 0, sizeof(tlist_item));
     }
   }
@@ -222,7 +222,7 @@ void print_items(void)
     printf("%d: %s - \"%s\" - author: %s\n",
         cnt, pfinfo->title, pfinfo->filename, pfinfo->author);
 
-    ptr = ptr->next;
+    ptr = (tlist_item*)ptr->next;
     cnt++;
   }
 }
@@ -397,7 +397,7 @@ char* download_file_from_filehost(int fileidx)
   {
     if (fileidx == cnt)
       break;
-    ptr = ptr->next;
+    ptr = (tlist_item*)ptr->next;
     cnt++;
   }
 

--- a/src/tools/filehost.h
+++ b/src/tools/filehost.h
@@ -1,6 +1,7 @@
 #ifndef FILEHOST_H
 #define FILEHOST_H
 
+void log_in_and_get_cookie(char* username, char* password);
 void read_filehost_struct(void);
 char* download_file_from_filehost(int fileidx);
 

--- a/src/tools/filehost.h
+++ b/src/tools/filehost.h
@@ -3,4 +3,5 @@
 
 void read_filehost_struct(void);
 char* download_file_from_filehost(int fileidx);
+
 #endif // FILEHOST_H

--- a/src/tools/filehost.h
+++ b/src/tools/filehost.h
@@ -1,0 +1,6 @@
+#ifndef FILEHOST_H
+#define FILEHOST_H
+
+void read_filehost_struct(void);
+char* download_file_from_filehost(int fileidx);
+#endif // FILEHOST_H

--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -1440,6 +1440,7 @@ void enterTestMode()
 
 unsigned char checkUSBPermissions()
 {
+#ifndef WINDOWS
   libusb_device_handle* usbhandle = NULL;
   struct libusb_context* usb_context;
   libusb_device** device_list;
@@ -1459,6 +1460,7 @@ unsigned char checkUSBPermissions()
       return 0;
     }
   }
+#endif
 
   return 1;
 }

--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -2528,6 +2528,6 @@ void do_exit(int retval)
       pthread_join(threads[i], NULL);
   }
 #endif
-  close_tcp_port();
+  close_default_tcp_port();
   exit(retval);
 }

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -110,6 +110,7 @@ int no_rxbuff = 1;
 
 int saw_c64_mode = 0;
 int saw_c65_mode = 0;
+int saw_openrom  = 0;
 
 int serial_speed = 2000000;
 
@@ -1037,6 +1038,7 @@ int detect_mode(void)
   */
   saw_c65_mode = 0;
   saw_c64_mode = 0;
+  saw_openrom = 0;
 
   unsigned char mem_buff[8192];
 
@@ -1047,6 +1049,7 @@ int detect_mode(void)
     int date_code = atoi((const char*)&mem_buff[1]);
     if (date_code > 2000000) {
       fprintf(stderr, "Detected OpenROM version %d\n", date_code);
+      saw_openrom = 1;
       saw_c64_mode = 1;
       return 0;
     }

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -174,12 +174,12 @@ int do_slow_write(PORT_TYPE fd, char* d, int l, const char* func, const char* fi
 void do_write(PORT_TYPE localfd, char* str)
 {
   int len = strlen(str);
-  do_serial_port_write(localfd, str, len, NULL, NULL, 0);
+  do_serial_port_write(localfd, (uint8_t*)str, len, NULL, NULL, 0);
 }
 
 int do_read(PORT_TYPE localfd, char* str, int max)
 {
-  return do_serial_port_read(localfd, str, max, NULL, NULL, 0);
+  return do_serial_port_read(localfd, (uint8_t*)str, max, NULL, NULL, 0);
 }
 
 int do_slow_write_safe(PORT_TYPE fd, char* d, int l, const char* func, const char* file, int line)

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -1650,7 +1650,25 @@ void close_tcp_port(PORT_TYPE localfd)
   // TODO: do I need to do any nice closing of the socket in linux too?
 }
 
+// provide an implementation of stricmp for linux/mac
+int stricmp(const char *a, const char *b)
+{
+  int ca, cb;
+  do {
+     ca = (unsigned char) *a++;
+     cb = (unsigned char) *b++;
+     ca = tolower(toupper(ca));
+     cb = tolower(toupper(cb));
+   } while (ca == cb && ca != '\0');
+   return ca - cb;
+}
+
 #endif
+
+void close_default_tcp_port(void)
+{
+  close_tcp_port(fd);
+}
 
 void open_the_serial_port(char* serial_port)
 {

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -868,7 +868,7 @@ int push_ram(unsigned long address, unsigned int count, unsigned char* buffer)
       if (no_rxbuff)
         do_usleep(1000 * SLOW_FACTOR);
       if (xemu_flag)
-        do_usleep(5000 * SLOW_FACTOR);
+        do_usleep(50000 * SLOW_FACTOR);
       int n = b;
       unsigned char* p = &buffer[offset];
       while (n > 0) {
@@ -876,9 +876,12 @@ int push_ram(unsigned long address, unsigned int count, unsigned char* buffer)
         if (w > 0) {
           p += w;
           n -= w;
+          if (xemu_flag)
+            do_usleep(50000 * SLOW_FACTOR);
         }
-        else
+        else {
           do_usleep(1000 * SLOW_FACTOR);
+        }
       }
     }
     wait_for_prompt();
@@ -1520,6 +1523,7 @@ int hostname_to_ip(char* hostname, char* ip)
 #ifdef WINDOWS
 int open_tcp_port(char* portname)
 {
+  xemu_flag = 1;
   char hostname[128] = "localhost";
   char port[128] = "4510"; // assume a default port of 4510
   if (portname[3] == '#')  // did user provide a hostname and port number?

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -110,7 +110,7 @@ int no_rxbuff = 1;
 
 int saw_c64_mode = 0;
 int saw_c65_mode = 0;
-int saw_openrom  = 0;
+int saw_openrom = 0;
 
 int serial_speed = 2000000;
 
@@ -1545,8 +1545,7 @@ PORT_TYPE open_tcp_port(char* portname)
   {
     sscanf(&portname[4], "%[^:]:%s", hostname, port);
   }
-  else if (portname[3] == '\\' && portname[4] == '#')
-  {
+  else if (portname[3] == '\\' && portname[4] == '#') {
     sscanf(&portname[5], "%[^:]:%s", hostname, port);
   }
 

--- a/src/tools/m65common.c
+++ b/src/tools/m65common.c
@@ -544,7 +544,7 @@ int dump_bytes(int col, char* msg, unsigned char* bytes, int length)
       if (i + j < length)
         fprintf(stderr, " %02X", bytes[i + j]);
       else
-        fprintf(stderr, "   ");
+        fprintf(stderr, " | ");
     fprintf(stderr, "  ");
     for (int j = 0; j < 16; j++)
       if (i + j < length)

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -544,9 +544,6 @@ int execute_command(char* cmd)
     clustermap_count = 1;
     show_clustermap();
   }
-  else if (sscanf(cmd, "clusters %s", src) == 1) {
-    download_file(src, src, 1);
-  }
   else if (sscanf(cmd, "cluster %d", &cluster_num) == 1) {
     show_cluster();
   }

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -2194,7 +2194,7 @@ void show_local_directory(char* searchpattern)
 
 void show_local_pwd(void)
 {
-  char cwd[MAX_PATH];
+  char cwd[4096];
   if (getcwd(cwd, sizeof(cwd)) != NULL) {
     printf("%s\n", cwd);
   }
@@ -2595,7 +2595,9 @@ int contains_file(char* name)
     }
   }
   if (dir_sector == -1)
-    return 0;
+    return -1;
+
+  return 0;
 }
 
 int rename_file(char* name, char* dest_name)
@@ -2603,12 +2605,12 @@ int rename_file(char* name, char* dest_name)
   int retVal = 0;
   do {
 
-    if (!contains_file(name)) {
+    if (contains_file(name)) {
       printf("ERROR: File %s does not exist.\n", name);
       return -1;
     }
 
-    if (contains_file(dest_name)) {
+    if (contains_file(dest_name) == 1) {
       printf("ERROR: Cannot rename to \"%s\", as this file already exists.\n", dest_name);
       return -2;
     }

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -118,6 +118,7 @@ BOOL find_file_in_curdir(char* filename, struct m65dirent* de);
 BOOL create_directory_entry_for_file(char* filename);
 unsigned int calc_first_cluster_of_file(void);
 BOOL is_d81_file(char* filename);
+void wrap_upload(char* fname);
 
 // Helper routine for faster sector writing
 extern unsigned int helperroutine_len;
@@ -415,6 +416,9 @@ int execute_command(char* cmd)
   else if (parse_command(cmd, "put %s %s", src, dst) == 2) {
     upload_file(src, dst);
   }
+  else if (parse_command(cmd, "wput %s", src) == 1) {
+    wrap_upload(src);
+  }
   else if (parse_command(cmd, "del %s", src) == 1) {
     delete_file(src);
   }
@@ -548,6 +552,7 @@ int execute_command(char* cmd)
     printf("cd [directory] - change current working directory.\n");
     printf("put <file> [destination name] - upload file to SD card, and optionally rename it destination file.\n");
     printf("get <file> [destination name] - download file from SD card, and optionally rename it destination file.\n");
+    printf("wput <file> - upload .prg file wrapped into a .d81 file\n");
     printf("del <file> - delete a file from SD card.\n");
     printf("mkdir <dirname> - create a directory on the SD card.\n");
     printf("cd <dirname> - change directory on the SD card. (aka. 'chdir')\n");
@@ -2136,6 +2141,21 @@ void perform_filehost_read(void)
   }
 
   read_filehost_struct();
+}
+
+void wrap_upload(char* fname)
+{
+  char* d81name = create_d81_for_prg(fname);
+  strcpy(fname, d81name);
+
+  if (fname)
+  {
+    upload_file(fname, fname);
+  }
+  else
+  {
+    printf("ERROR: Unable to download file from filehost!\n");
+  }
 }
 
 void perform_filehost_get(int num)

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -2591,8 +2591,9 @@ int contains_file(char* name)
       return 1;
     }
   }
+  // if dir-sector = -1, that means we got to the end of the directory entries without finding a match
   if (dir_sector == -1)
-    return -1;
+    return 0;
 
   return 0;
 }

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -2587,7 +2587,7 @@ int contains_file(char* name)
     // else dump_bytes(0,"empty dirent",&dir_sector_buffer[dir_sector_offset],32);
     if (!strcasecmp(de.d_name, name)) {
       // Found file, so will replace it
-      printf("Found \"%s\" on the file system, beginning at cluster %d\n", name, (int)de.d_ino);
+      // printf("Found \"%s\" on the file system, beginning at cluster %d\n", name, (int)de.d_ino);
       return 1;
     }
   }

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -49,6 +49,8 @@
 #define TRUE 1
 #define FALSE 0
 
+#define DT_FREESLOT 0xff
+
 #define SECTOR_CACHE_SIZE 4096
 int sector_cache_count = 0;
 unsigned char sector_cache[SECTOR_CACHE_SIZE][512];
@@ -84,6 +86,14 @@ char current_dir[1024] = "/";
 int open_file_system(void);
 int download_slot(int sllot, char* dest_name);
 int download_file(char* dest_name, char* local_name, int showClusters);
+void show_clustermap(void);
+void show_cluster(void);
+void dump_sectors(void);
+void restore_sectors(void);
+void show_secinfo(void);
+void show_mbrinfo(void);
+void show_vbrinfo(void);
+void poke_sector(void);
 int show_directory(char* path);
 int delete_file(char* name);
 int rename_file(char* name, char* dest_name);
@@ -163,6 +173,19 @@ unsigned char mbr[512];
 unsigned char fat_mbr[512];
 unsigned char syspart_sector0[512];
 unsigned char syspart_configsector[512];
+
+int dirent_raw = 0;
+int clustermap_start = 0;
+int clustermap_count = 0;
+int cluster_num = 0;
+char secdump_file[256] = { 0 };
+int secdump_start = 0;
+int secdump_count = 0;
+char secrestore_file[256] = { 0 };
+int secrestore_start = 0;
+int poke_secnum = 0;
+int poke_offset = 0;
+int poke_value = 0;
 
 #define M65DT_REG 1
 #define M65DT_DIR 2
@@ -396,8 +419,9 @@ int execute_command(char* cmd)
   }
   else if (parse_command(cmd, "sector $%x", &sector_num) == 1) {
     show_sector(sector_num);
-  }
-  else if (parse_command(cmd, "dir %s", src) == 1) {
+  } else if (sscanf(cmd,"dirent_raw %d", &dirent_raw) == 1) {
+    printf("dirent_raw = %d\n", dirent_raw);
+  } else if (parse_command(cmd, "dir %s", src) == 1) {
     show_directory(src);
   }
   else if (!strcmp(cmd, "dir")) {
@@ -483,17 +507,51 @@ int execute_command(char* cmd)
   }
   else if (parse_command(cmd, "mount %s", src) == 1) {
     mount_file(src);
-  }
-  else if (!strcasecmp(cmd, "help")) {
+  } else if (sscanf(cmd, "clustermap %d %d", &clustermap_start, &clustermap_count)==2) {
+    show_clustermap();
+  } else if (sscanf(cmd, "clustermap %d", &clustermap_start)==1) {
+    clustermap_count = 1;
+    show_clustermap();
+  } else if (sscanf(cmd,"clusters %s",src)==1) {
+    download_file(src,src,1);
+  } else if (sscanf(cmd,"cluster %d", &cluster_num)==1) {
+    show_cluster();
+  } else if (sscanf(cmd,"secdump %s %d %d", secdump_file, &secdump_start, &secdump_count)==3) {
+    dump_sectors();
+  } else if (sscanf(cmd, "secrestore %s %d", secrestore_file, &secrestore_start)==2) {
+    restore_sectors();
+  } else if (!strcmp(cmd, "secinfo")) {
+    show_secinfo();
+  } else if (!strcmp(cmd, "mbrinfo")) {
+    show_mbrinfo();
+  } else if (!strcmp(cmd, "vbrinfo")) {
+    show_vbrinfo();
+  } else if (sscanf(cmd, "poke %d %d %d", &poke_secnum, &poke_offset, &poke_value)==3) {
+    poke_sector();
+  } else if (!strcasecmp(cmd,"help")) {
     printf("MEGA65 File Transfer Program Command Reference:\n");
     printf("\n");
     printf("dir [directory] - show contents of current or specified directory.\n");
     printf("cd [directory] - change current working directory.\n");
     printf("put <file> [destination name] - upload file to SD card, and optionally rename it destination file.\n");
     printf("get <file> [destination name] - download file from SD card, and optionally rename it destination file.\n");
+    printf("del <file> - delete a file from SD card.\n");
+    printf("mkdir <dirname> - create a directory on the SD card.\n");
+    printf("cd <dirname> - change directory on the SD card. (aka. 'chdir')\n");
+    printf("rename <oldname> <newname> - rename a file on the SD card.\n");
     printf("clusters <file> - show cluster chain of specified file.\n");
+    printf("mount <d81file> - Mount the specified .d81 file (which resides on the SD card).\n");
     printf("sector <number|$hex number> - display the contents of the specified sector.\n");
     printf("getslot <slot> <destination name> - download a freeze slot.\n");
+    printf("dirent_raw 0|1 - flag to hide/show 32-byte dump of directory entries.\n");
+    printf("clustermap <startidx> [<count>] - show cluster-map entries for specified range.\n");
+    printf("cluster <num> - dump the entire contents of this cluster.\n");
+    printf("secdump <filename> <startsec> <count> - dump the specified sector range to a file.\n");
+    printf("secrestore <filename> <startsec> - restore a dumped file back into the specified sector area.\n");
+    printf("secinfo - lists the locations of various useful sectors, for easy reference.\n");
+    printf("mbrinfo - lists the partitions specified in the MBR (sector 0)\n");
+    printf("vbrinfo - lists the VBR details of the main Mega65 partition\n");
+    printf("poke <sector> <offset> <val> - poke a value into a sector, at the desired offset.\n");
     printf("exit - leave this programme.\n");
     printf("quit - leave this programme.\n");
   }
@@ -1305,6 +1363,8 @@ unsigned int get_next_cluster(int cluster)
     retVal = (buf[cluster_sector_offset + 0] << 0) | (buf[cluster_sector_offset + 1] << 8)
            | (buf[cluster_sector_offset + 2] << 16) | (buf[cluster_sector_offset + 3] << 24);
 
+    // mask out highest 4 bits (these seem to be flags on some systems)
+    retVal &= 0x0fffffff;
   } while (0);
   return retVal;
 }
@@ -1398,36 +1458,93 @@ int fat_opendir(char* path)
   return retVal;
 }
 
+int advance_to_next_entry(void)
+{
+  int retVal = 0;
+
+  // Advance to next entry
+  dir_sector_offset+=32;
+  if (dir_sector_offset==512) {
+    dir_sector_offset=0;
+    dir_sector++;
+    dir_sector_in_cluster++;
+    if (dir_sector_in_cluster==sectors_per_cluster) {
+      // Follow to next cluster
+      int next_cluster=get_next_cluster(dir_cluster);
+      if (next_cluster<0xFFFFFF0&&next_cluster) {
+        dir_cluster=next_cluster;
+        dir_sector_in_cluster=0;
+        dir_sector=first_cluster_sector+(next_cluster-first_cluster)*sectors_per_cluster;
+      } else {
+        // End of directory reached
+        dir_sector=-1;
+        retVal=-2;
+        return retVal;
+      }
+    }
+    if (dir_sector!=-1) retVal=read_sector(partition_start+dir_sector,dir_sector_buffer, CACHE_YES, 0);
+    if (retVal) dir_sector=-1;      
+  }    
+
+  return retVal;
+}
+
+void debug_vfatchunk(void)
+{
+  int start = 0x01;
+  int len = 5;
+
+  for (int k = start; k < (start+len*2); k+=2)
+    printf("%c", dir_sector_buffer[dir_sector_offset+k]);
+
+  start = 0x0E;
+  len = 6;
+
+  for (int k = start; k < (start+len*2); k+=2)
+    printf("%c", dir_sector_buffer[dir_sector_offset+k]);
+
+  start = 0x1C;
+  len = 2;
+
+  for (int k = start; k < (start+len*2); k+=2)
+    printf("%c", dir_sector_buffer[dir_sector_offset+k]);
+
+  printf("\n");
+}
+
+void copy_to_dnamechunk_from_offset(char* dnamechunk, int offset, int numuc2chars)
+{
+  for (int k = 0; k < numuc2chars; k++)
+  {
+    dnamechunk[k] = dir_sector_buffer[dir_sector_offset+offset+k*2];
+  }
+}
+
+void copy_vfat_chars_into_dname(char* dname, int seqnumber)
+{
+  // increment char-pointer to the seqnumber string chunk we'll copy across
+  dname = dname + 13 * (seqnumber-1);
+  copy_to_dnamechunk_from_offset(dname, 0x01, 5);
+  dname += 5;
+  copy_to_dnamechunk_from_offset(dname, 0x0E, 6);
+  dname += 6;
+  copy_to_dnamechunk_from_offset(dname, 0x1C, 2);
+}
+
 int fat_readdir(struct m65dirent* d)
 {
   int retVal = 0;
-  do {
+  int vfatEntry = 0;
+  int deletedEntry = 0;
+  d->d_type = 0;
 
-    // Advance to next entry
-    dir_sector_offset += 32;
-    if (dir_sector_offset == 512) {
-      dir_sector_offset = 0;
-      dir_sector++;
-      dir_sector_in_cluster++;
-      if (dir_sector_in_cluster == sectors_per_cluster) {
-        // Follow to next cluster
-        int next_cluster = get_next_cluster(dir_cluster);
-        if (next_cluster < 0xFFFFFF0 && next_cluster) {
-          dir_cluster = next_cluster;
-          dir_sector_in_cluster = 0;
-          dir_sector = first_cluster_sector + (next_cluster - first_cluster) * sectors_per_cluster;
-        }
-        else {
-          // End of directory reached
-          dir_sector = -1;
-          retVal = -1;
-          break;
-        }
-      }
-      if (dir_sector != -1)
-        retVal = read_sector(partition_start + dir_sector, dir_sector_buffer, CACHE_YES, 0);
-      if (retVal)
-        dir_sector = -1;
+  do {
+    retVal = advance_to_next_entry();
+
+    if (retVal == -2) // exiting due to end-of-directory?
+    {
+      retVal = -1;
+      break;
     }
 
     if (dir_sector == -1) {
@@ -1441,31 +1558,125 @@ int fat_readdir(struct m65dirent* d)
 
     // printf("Found dirent %d %d %d\n",dir_sector,dir_sector_offset,dir_sector_in_cluster);
 
-    // XXX - Support FAT32 long names!
+    // Read in all FAT32-VFAT entries to extract out long filenames
+    if (dir_sector_buffer[dir_sector_offset+0x0B] == 0x0F) {
+      vfatEntry = 1;
+      int firstTime = 1;
+      int seqnumber;
+      do
+      {
+        // printf("seq = 0x%02X\n", dir_sector_buffer[dir_sector_offset+0x00]);
+        // debug_vfatchunk();
+        int seq = dir_sector_buffer[dir_sector_offset+0x00];
+
+        if (seq == 0xE5)  // if deleted-entry, then ignore
+        {
+          //printf("deleteentry!\n");
+          deletedEntry=1;
+        }
+
+        seqnumber = seq & 0x1F;
+
+        // assure there is a null-terminator
+        if (firstTime)
+        {
+          d->d_name[seqnumber*13] = 0;
+          firstTime = 0;
+        }
+
+        // vfat seqnumbers will be parsed from high to low, each containing up to 13 UCS-2 characters
+        copy_vfat_chars_into_dname(d->d_name, seqnumber);
+        advance_to_next_entry();
+
+        // if next dirent is not a vfat entry, break out
+        if (dir_sector_buffer[dir_sector_offset+0x0B] != 0x0F)
+          break;
+      } while (seqnumber != 1);
+    }
+
+    // ignore any vfat files starting with '.' (such as mac osx '._*' metadata files)
+    if (vfatEntry && d->d_name[0] == '.') {
+      //printf("._ vfat hide\n");
+      d->d_name[0] = 0;
+      return 0;
+    }
+
+    // ignored deleted vfat entries too (mac osx '._*' files are marked as deleted entries)
+    if (deletedEntry)
+    {
+      d->d_name[0] = 0;
+      return 0;
+    }
+    
+    // if the DOS 8.3 entry is a deleted-entry, then ignore
+    if (dir_sector_buffer[dir_sector_offset] == 0xE5)
+    {
+      d->d_name[0] = 0;
+      return 0;
+    }
+
+    int attrib = dir_sector_buffer[dir_sector_offset+0x0B];
+
+    // if this is the volume-name of the partition, then ignore
+    if (attrib == 0x08) {
+      d->d_name[0] = 0;
+      return 0;
+    }
+
+    // if the hidden attribute is turned on, then ignore
+    if (attrib & 0x02) {
+      d->d_name[0] = 0;
+      return 0;
+    }
+
 
     // Put cluster number in d_ino
     d->d_ino = (dir_sector_buffer[dir_sector_offset + 0x1A] << 0) | (dir_sector_buffer[dir_sector_offset + 0x1B] << 8)
              | (dir_sector_buffer[dir_sector_offset + 0x14] << 16) | (dir_sector_buffer[dir_sector_offset + 0x15] << 24);
 
-    int namelen = 0;
-    if (dir_sector_buffer[dir_sector_offset]) {
-      for (int i = 0; i < 8; i++)
-        if (dir_sector_buffer[dir_sector_offset + i])
-          d->d_name[namelen++] = dir_sector_buffer[dir_sector_offset + i];
-      while (namelen && d->d_name[namelen - 1] == ' ')
-        namelen--;
-    }
-    if (dir_sector_buffer[dir_sector_offset + 8] && dir_sector_buffer[dir_sector_offset + 8] != ' ') {
-      d->d_name[namelen++] = '.';
-      for (int i = 0; i < 3; i++)
-        if (dir_sector_buffer[dir_sector_offset + 8 + i])
-          d->d_name[namelen++] = dir_sector_buffer[dir_sector_offset + 8 + i];
-      while (namelen && d->d_name[namelen - 1] == ' ')
-        namelen--;
-    }
-    d->d_name[namelen] = 0;
+    // if not vfat-longname, then extract out old 8.3 name
+    if (!vfatEntry)
+    {
+      int namelen=0;
+      int nt_flags = dir_sector_buffer[dir_sector_offset+0x0C];
+      int basename_lowercase = nt_flags & 0x08;
+      int extension_lowercase = nt_flags & 0x10;
 
-    //    if (d->d_name[0]) dump_bytes(0,"dirent raw",&dir_sector_buffer[dir_sector_offset],32);
+      // get the 8-byte filename
+      if (dir_sector_buffer[dir_sector_offset]) {
+        for(int i=0;i<8;i++)
+        {
+          if (dir_sector_buffer[dir_sector_offset+i])
+          {
+            int c = dir_sector_buffer[dir_sector_offset+i];
+            if (basename_lowercase)
+              c = tolower(c);
+            d->d_name[namelen++]=c;
+          }
+        }
+        while(namelen&&d->d_name[namelen-1]==' ') namelen--;
+      }
+      // get the 3-byte extension
+      if (dir_sector_buffer[dir_sector_offset+8]&&dir_sector_buffer[dir_sector_offset+8]!=' ') {
+        d->d_name[namelen++]='.';
+        for(int i=0;i<3;i++)
+        {
+          if (dir_sector_buffer[dir_sector_offset+8+i])
+          {
+            int c = dir_sector_buffer[dir_sector_offset+8+i];
+            if (extension_lowercase)
+              c = tolower(c);
+            d->d_name[namelen++]=c;
+          }
+        }
+        while(namelen&&d->d_name[namelen-1]==' ') namelen--;
+      }
+      d->d_name[namelen]=0;
+    }
+
+    if (dirent_raw && d->d_name[0])
+      dump_bytes(0,"dirent raw",&dir_sector_buffer[dir_sector_offset],32);
+
 
     d->d_filelen = (dir_sector_buffer[dir_sector_offset + 0x1C] << 0) | (dir_sector_buffer[dir_sector_offset + 0x1D] << 8)
                  | (dir_sector_buffer[dir_sector_offset + 0x1E] << 16) | (dir_sector_buffer[dir_sector_offset + 0x1F] << 24);
@@ -1783,6 +1994,214 @@ int check_file_system_access(void)
   return retVal;
 }
 
+int read_int32_from_offset_in_buffer(int offset)
+{
+  int val =
+    (dir_sector_buffer[offset]<<0)
+    |(dir_sector_buffer[offset+1]<<8)
+    |(dir_sector_buffer[offset+2]<<16)
+    |(dir_sector_buffer[offset+3]<<24);
+
+  return val;
+}
+
+void show_clustermap(void)
+{
+  int clustermap_end = clustermap_start + clustermap_count;
+  int previous_clustermap_sector = 0;
+  int abs_fat1_sector = partition_start + fat1_sector;
+
+  for (int clustermap_idx = clustermap_start; clustermap_idx < clustermap_end; clustermap_idx++)
+  {
+    int clustermap_sector = abs_fat1_sector + (clustermap_idx*4) / 512;
+    int clustermap_offset = (clustermap_idx*4) % 512;
+
+    //printf("clustermap_sector = %d\nclustermap_offset=%d\n", clustermap_sector, clustermap_offset);
+
+    // do we need to read in the next sector?
+    if (clustermap_sector != previous_clustermap_sector)
+    {
+      int retVal=read_sector(clustermap_sector,dir_sector_buffer, CACHE_YES, 0);
+      if (retVal)
+      {
+        fprintf(stderr, "Failed to read next sector(%d)\n", clustermap_sector);
+        return;
+      }
+      previous_clustermap_sector = clustermap_sector;
+    }
+
+    int clustermap_val = read_int32_from_offset_in_buffer(clustermap_offset);
+    clustermap_val &= 0x0fffffff; // map out flags in top 4 bits
+    printf("%d:  %d  ($%08X)\n", clustermap_idx, clustermap_val, clustermap_val);
+  }
+}
+
+void show_cluster(void)
+{
+  char str[50];
+  int abs_cluster2_sector = partition_start + first_cluster_sector + (cluster_num-2)*sectors_per_cluster;
+
+  for (int idx = 0; idx < sectors_per_cluster; idx++)
+  {
+    read_sector(abs_cluster2_sector + idx, dir_sector_buffer, CACHE_YES, 0);
+    sprintf(str, "Sector %d:\n", abs_cluster2_sector + idx);
+    dump_bytes(0,str,dir_sector_buffer,512);
+  }
+}
+
+void dump_sectors(void)
+{
+  FILE* fsave = fopen(secdump_file, "wb");
+  for (int sector = secdump_start; sector < (secdump_start+secdump_count); sector++)
+  {
+    read_sector(sector, dir_sector_buffer, CACHE_YES, 0);
+    fwrite(dir_sector_buffer, 1, 512, fsave);
+    printf("\rSaving... (%d%%)", (sector-secdump_start)*100/secdump_count);
+  }
+  fclose(fsave);
+  printf("\rSaved to file \"%s\".         \n", secdump_file);
+}
+
+void restore_sectors(void)
+{
+  struct stat st;
+  stat(secrestore_file, &st);
+  int secrestore_count = st.st_size / 512;
+
+  FILE* fload = fopen(secrestore_file, "rb");
+  for (int sector = secrestore_start; sector < (secrestore_start+secrestore_count); sector++)
+  {
+    fread(dir_sector_buffer, 1, 512, fload);
+    write_sector(sector, dir_sector_buffer);
+    printf("\rLoading... (%d%%)", (sector-secrestore_start)*100/secrestore_count);
+  }
+  fclose(fload);
+  printf("\rLoaded file \"%s\" at starting-sector %d.\n", secrestore_file, secrestore_start);
+}
+
+void poke_sector(void)
+{
+    read_sector(poke_secnum, dir_sector_buffer, CACHE_NO, 0);
+    dir_sector_buffer[poke_offset] = poke_value;
+    write_sector(poke_secnum, dir_sector_buffer);
+}
+
+void show_secinfo(void)
+{
+  int abs_fat1_sector = partition_start + fat1_sector;
+  int abs_fat2_sector = partition_start + fat2_sector;
+  int abs_cluster2_sector = partition_start + first_cluster_sector;
+
+  if (!file_system_found) open_file_system();
+  printf("\n");
+  printf("  SECTOR : CONTENT\n");    
+  printf("  ------   -------\n");
+  printf("% 8d : MBR (Master Boot Record)\n", 0);
+  printf("% 8d : VBR of 1st Partition\n", partition_start);
+  printf("% 8d : 1st FAT (cluster-chain map)\n", abs_fat1_sector);
+  printf("% 8d : 2nd FAT (backup)\n", abs_fat2_sector);
+  printf("% 8d : cluster #2 (root-directory table)\n", abs_cluster2_sector);
+  printf("\n");
+}
+
+void show_vbrinfo(void)
+{
+  unsigned char sector[512];
+  if (!file_system_found) open_file_system();
+  if (read_sector(partition_start,sector, CACHE_YES, 0))
+  {
+    printf("Failed to read sector %d...\n", partition_start);
+    return;
+  }
+
+  printf("OEM Name=\"%c%c%c%c%c%c%c%c\"\n",
+      sector[0x03], sector[0x04], sector[0x05], sector[0x06],
+      sector[0x07], sector[0x08], sector[0x09], sector[0x0A]);
+  printf("FAT32 Extended BIOS Parameter Block:\n");
+  printf("{\n");
+  printf("  DOS 3.31 BPB\n");
+  printf("  {\n");
+  printf("    DOS 2.0 BPB\n");
+  printf("    {\n");
+  printf("      Bytes per logical sector = %d\n", *(unsigned short*)&sector[0x0B]);
+  printf("      Logical sectors per cluster = %d\n", sector[0x0D]);
+  printf("      Count of reserved logical sectors before 1st FAT = %d\n", *(unsigned short*)&sector[0x0E]);
+  printf("      Number of FATs = %d\n", sector[0x10]);
+  printf("      Max no# of FAT12/16 root dir entries = %d\n", *(unsigned short*)&sector[0x11]);
+  printf("      Total logical sector (0 for FAT32) = %d\n", *(unsigned short*)&sector[0x13]);
+  printf("      Media Descriptor = 0x%02X\n", sector[0x15]);
+  printf("      Logical sectors per FAT (0 for FAT32) = %d\n", *(unsigned short*)&sector[0x16]);
+  printf("    }\n");
+  printf("    Physical sectors per track (for INT 13h CHS geometry) = %d\n", *(unsigned short*)&sector[0x18]);
+  printf("    Number of heads (for disks with INT 13h CHS geometry) = %d\n", *(unsigned short*)&sector[0x1A]);
+  printf("    Count of hidden sectors preceding the partition of this FAT volume = %d\n", *(unsigned int*)&sector[0x1C]);
+  printf("    Total logical sectors (if greater than 65535) = %d\n", *(unsigned int*)&sector[0x20]);
+  printf("  }\n");
+  printf("  Logical sectors per FAT = %d\n", *(unsigned int*)&sector[0x24]);
+  printf("  Drive description / mirroring flags = 0x%02X 0x%02X\n", sector[0x28], sector[0x29]);
+  printf("  Version = 0x%02X 0x%02X\n", sector[0x2A], sector[0x2B]);
+  printf("  Cluster number of root directory start = %d\n", *(unsigned int*)&sector[0x2C]);
+  printf("  Logical sector number of FS Information Sector = %d\n", *(unsigned short*)&sector[0x30]);
+  printf("  First logical sector number of copy of 3 FAT boot sectors = %d\n", *(unsigned short*)&sector[0x32]);
+  printf("  Cf. 0x024 for FAT12/FAT16 (Physical Drive Number) = 0x%02X\n", sector[0x40]);
+  printf("  Cf. 0x025 for FAT12/FAT16 (Used for various purposes; see FAT12/FAT16) = 0x%02X\n", sector[0x41]);
+  printf("  Cf. 0x026 for FAT12/FAT16 (Extended boot signature, 0x29) = 0x%02X\n", sector[0x42]);
+  printf("  Cf. 0x027 for FAT12/FAT16 (Volume ID) = %02X %02X %02X %02X\n", sector[0x43], sector[0x44], sector[0x45], sector[0x46]);
+  printf("  Cf. 0x02B for FAT12/FAT16 (Volume Label) = %c%c%c%c%c%c%c%c%c%c%c\n",
+      sector[0x47], sector[0x48], sector[0x49], sector[0x4a],
+      sector[0x4b], sector[0x4c], sector[0x4d], sector[0x4e],
+      sector[0x4f], sector[0x50], sector[0x51]);
+  printf("  Cf. 0x036 for FAT12/FAT16 (File system type) = %c%c%c%c%c%c%c%c\n",
+      sector[0x52], sector[0x53], sector[0x54], sector[0x55],
+      sector[0x56], sector[0x57], sector[0x58], sector[0x59]);
+  printf("}\n");
+
+  printf("\n");
+}
+
+void show_mbrinfo(void)
+{
+  unsigned char sector[512];
+  if (!file_system_found) open_file_system();
+  if (read_sector(0,sector, CACHE_YES, 0))
+  {
+    printf("Failed to read sector 0...\n");
+    return;
+  }
+
+  int pt_ofs=0x1be;
+  int part_cnt = 0;
+
+  for (int part_id = 0; part_id < 4; part_id++)
+  {
+    if (sector[pt_ofs+0x04] == 0x00) // is partition-type 0? (unused)
+      continue;
+
+    printf("Partition %d\n", part_id);
+    printf("-----------\n");
+    if (sector[pt_ofs] == 0x80)
+      printf("- active/bootable partition\n");
+    printf("- Partition type = 0x%02X\n", sector[pt_ofs+0x04]);
+    int c = sector[pt_ofs+0x03] + ((sector[pt_ofs+0x02] & 0xC0) << 2);
+    int h = sector[pt_ofs+0x02] & 0x3F;
+    int s = sector[pt_ofs+0x01];
+    printf("- First sector chs: cylinder = %d, head = %d, sector = %d\n", c, h, s);
+    c = sector[pt_ofs+0x07] + ((sector[pt_ofs+0x06] & 0xC0) << 2);
+    h = sector[pt_ofs+0x06] & 0x3F;
+    s = sector[pt_ofs+0x05];
+    printf("- Last sector chs: cylinder = %d, head = %d, sector = %d\n", c, h, s);
+    printf("- First sector LBA: %d\n", *(unsigned int*)&sector[pt_ofs+0x08]);
+    printf("- Number of sectors: %d\n", *(unsigned int*)&sector[pt_ofs+0x0C]);
+    
+    part_cnt++;
+    printf("\n");
+
+    pt_ofs += 16;
+  }
+  if (part_cnt == 0)
+    printf("No partitions found!\n\n");
+}
+
 unsigned int get_first_cluster_of_file(void)
 {
   return (dir_sector_buffer[dir_sector_offset + 0x1A] << 0) | (dir_sector_buffer[dir_sector_offset + 0x1B] << 8)
@@ -2033,7 +2452,7 @@ int upload_file(char* name, char* dest_name)
       }
       struct m65dirent de;
       while (!fat_readdir(&de)) {
-        if (!de.d_name[0]) {
+        if (!de.d_name[0] && de.d_type==DT_FREESLOT) {
           if (0)
             printf("Found empty slot at dir_sector=%d, dir_sector_offset=%d\n", dir_sector, dir_sector_offset);
 

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -2613,6 +2613,9 @@ int rename_file(char* name, char* dest_name)
       return -2;
     }
 
+    // need to call this again to set various global variable details for the found file properly
+    contains_file(name);
+
     // Write name
     for (int i = 0; i < 11; i++)
       dir_sector_buffer[dir_sector_offset + i] = 0x20;

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -94,6 +94,7 @@ void show_secinfo(void);
 void show_mbrinfo(void);
 void show_vbrinfo(void);
 void poke_sector(void);
+void perform_filehost_read(void);
 void perform_filehost_get(int num);
 int show_directory(char* path);
 int delete_file(char* name);
@@ -142,6 +143,8 @@ int mode_report = 0;
 
 char serial_port[1024] = "/dev/ttyUSB1";
 char* bitstream = NULL;
+char* username = NULL;
+char* password = NULL;
 
 unsigned char* sd_read_buffer = NULL;
 int sd_read_offset = 0;
@@ -535,7 +538,7 @@ int execute_command(char* cmd)
   } else if (sscanf(cmd, "poke %d %d %d", &poke_secnum, &poke_offset, &poke_value)==3) {
     poke_sector();
   } else if (!strcmp(cmd, "fh")) {
-    read_filehost_struct();
+    perform_filehost_read();
   } else if (sscanf(cmd, "fhget %d", &fhnum) == 1) {
     perform_filehost_get(fhnum);
   }else if (!strcasecmp(cmd,"help")) {
@@ -588,7 +591,7 @@ int DIRTYMOCK(main)(int argc, char** argv)
   start_usec = gettime_us();
 
   int opt;
-  while ((opt = getopt(argc, argv, "b:Ds:l:c:")) != -1) {
+  while ((opt = getopt(argc, argv, "b:Ds:l:c:u:p:")) != -1) {
     switch (opt) {
     case 'D':
       debug_serial = 1;
@@ -614,6 +617,12 @@ int DIRTYMOCK(main)(int argc, char** argv)
       break;
     case 'c':
       queue_command(optarg);
+      break;
+    case 'u':
+      username = strdup(optarg);
+      break;
+    case 'p':
+      password = strdup(optarg);
       break;
     default: /* '?' */
       usage();
@@ -2117,6 +2126,16 @@ int endswith(char* fname, char* ext)
     return 1;
 
   return 0;
+}
+
+void perform_filehost_read(void)
+{
+  if (username != NULL)
+  {
+    log_in_and_get_cookie(username, password);
+  }
+
+  read_filehost_struct();
 }
 
 void perform_filehost_get(int num)

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -2605,7 +2605,7 @@ int rename_file(char* name, char* dest_name)
   int retVal = 0;
   do {
 
-    if (contains_file(name)) {
+    if (!contains_file(name)) {
       printf("ERROR: File %s does not exist.\n", name);
       return -1;
     }

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -572,8 +572,8 @@ int execute_command(char* cmd)
     perform_filehost_get(fhnum);
   }
   else if (!strcasecmp(cmd, "help")) {
-    printf("MEGA65 File Transfer Program Command Reference:\n");
-    printf("\n");
+    printf("MEGA65 File Transfer Program Command Reference:\n\n");
+
     printf("dir [directory|wildcardpattern] - show contents of current or specified sdcard directory. Can use a wildcard "
            "pattern on current directory.\n");
     printf("ldir [wildcardpattern] - shows the contents of current local directory.\n");

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -201,7 +201,6 @@ int fhnum = 0;
 #define M65DT_UNKNOWN 4
 #define M65DT_FREESLOT 0xff
 
-
 int sd_status_fresh = 0;
 unsigned char sd_status[16];
 
@@ -435,9 +434,11 @@ int execute_command(char* cmd)
   }
   else if (parse_command(cmd, "sector $%x", &sector_num) == 1) {
     show_sector(sector_num);
-  } else if (sscanf(cmd,"dirent_raw %d", &dirent_raw) == 1) {
+  }
+  else if (sscanf(cmd, "dirent_raw %d", &dirent_raw) == 1) {
     printf("dirent_raw = %d\n", dirent_raw);
-  } else if (parse_command(cmd, "dir %s", src) == 1) {
+  }
+  else if (parse_command(cmd, "dir %s", src) == 1) {
     show_directory(src);
   }
   else if (!strcmp(cmd, "dir")) {
@@ -535,35 +536,49 @@ int execute_command(char* cmd)
   }
   else if (parse_command(cmd, "mount %s", src) == 1) {
     mount_file(src);
-  } else if (sscanf(cmd, "clustermap %d %d", &clustermap_start, &clustermap_count)==2) {
+  }
+  else if (sscanf(cmd, "clustermap %d %d", &clustermap_start, &clustermap_count) == 2) {
     show_clustermap();
-  } else if (sscanf(cmd, "clustermap %d", &clustermap_start)==1) {
+  }
+  else if (sscanf(cmd, "clustermap %d", &clustermap_start) == 1) {
     clustermap_count = 1;
     show_clustermap();
-  } else if (sscanf(cmd,"clusters %s",src)==1) {
-    download_file(src,src,1);
-  } else if (sscanf(cmd,"cluster %d", &cluster_num)==1) {
+  }
+  else if (sscanf(cmd, "clusters %s", src) == 1) {
+    download_file(src, src, 1);
+  }
+  else if (sscanf(cmd, "cluster %d", &cluster_num) == 1) {
     show_cluster();
-  } else if (sscanf(cmd,"secdump %s %d %d", secdump_file, &secdump_start, &secdump_count)==3) {
+  }
+  else if (sscanf(cmd, "secdump %s %d %d", secdump_file, &secdump_start, &secdump_count) == 3) {
     dump_sectors();
-  } else if (sscanf(cmd, "secrestore %s %d", secrestore_file, &secrestore_start)==2) {
+  }
+  else if (sscanf(cmd, "secrestore %s %d", secrestore_file, &secrestore_start) == 2) {
     restore_sectors();
-  } else if (!strcmp(cmd, "secinfo")) {
+  }
+  else if (!strcmp(cmd, "secinfo")) {
     show_secinfo();
-  } else if (!strcmp(cmd, "mbrinfo")) {
+  }
+  else if (!strcmp(cmd, "mbrinfo")) {
     show_mbrinfo();
-  } else if (!strcmp(cmd, "vbrinfo")) {
+  }
+  else if (!strcmp(cmd, "vbrinfo")) {
     show_vbrinfo();
-  } else if (sscanf(cmd, "poke %d %d %d", &poke_secnum, &poke_offset, &poke_value)==3) {
+  }
+  else if (sscanf(cmd, "poke %d %d %d", &poke_secnum, &poke_offset, &poke_value) == 3) {
     poke_sector();
-  } else if (!strcmp(cmd, "fh")) {
+  }
+  else if (!strcmp(cmd, "fh")) {
     perform_filehost_read();
-  } else if (sscanf(cmd, "fhget %d", &fhnum) == 1) {
+  }
+  else if (sscanf(cmd, "fhget %d", &fhnum) == 1) {
     perform_filehost_get(fhnum);
-  }else if (!strcasecmp(cmd,"help")) {
+  }
+  else if (!strcasecmp(cmd, "help")) {
     printf("MEGA65 File Transfer Program Command Reference:\n");
     printf("\n");
-    printf("dir [directory|wildcardpattern] - show contents of current or specified sdcard directory. Can use a wildcard pattern on current directory.\n");
+    printf("dir [directory|wildcardpattern] - show contents of current or specified sdcard directory. Can use a wildcard "
+           "pattern on current directory.\n");
     printf("ldir [wildcardpattern] - shows the contents of current local directory.\n");
     printf("cd [directory] - change current sdcard working directory.\n");
     printf("lcd [directory] - change current local working directory.\n");
@@ -1511,28 +1526,31 @@ int advance_to_next_entry(void)
   int retVal = 0;
 
   // Advance to next entry
-  dir_sector_offset+=32;
-  if (dir_sector_offset==512) {
-    dir_sector_offset=0;
+  dir_sector_offset += 32;
+  if (dir_sector_offset == 512) {
+    dir_sector_offset = 0;
     dir_sector++;
     dir_sector_in_cluster++;
-    if (dir_sector_in_cluster==sectors_per_cluster) {
+    if (dir_sector_in_cluster == sectors_per_cluster) {
       // Follow to next cluster
-      int next_cluster=get_next_cluster(dir_cluster);
-      if (next_cluster<0xFFFFFF0&&next_cluster) {
-        dir_cluster=next_cluster;
-        dir_sector_in_cluster=0;
-        dir_sector=first_cluster_sector+(next_cluster-first_cluster)*sectors_per_cluster;
-      } else {
+      int next_cluster = get_next_cluster(dir_cluster);
+      if (next_cluster < 0xFFFFFF0 && next_cluster) {
+        dir_cluster = next_cluster;
+        dir_sector_in_cluster = 0;
+        dir_sector = first_cluster_sector + (next_cluster - first_cluster) * sectors_per_cluster;
+      }
+      else {
         // End of directory reached
-        dir_sector=-1;
-        retVal=-2;
+        dir_sector = -1;
+        retVal = -2;
         return retVal;
       }
     }
-    if (dir_sector!=-1) retVal=read_sector(partition_start+dir_sector,dir_sector_buffer, CACHE_YES, 0);
-    if (retVal) dir_sector=-1;      
-  }    
+    if (dir_sector != -1)
+      retVal = read_sector(partition_start + dir_sector, dir_sector_buffer, CACHE_YES, 0);
+    if (retVal)
+      dir_sector = -1;
+  }
 
   return retVal;
 }
@@ -1542,36 +1560,35 @@ void debug_vfatchunk(void)
   int start = 0x01;
   int len = 5;
 
-  for (int k = start; k < (start+len*2); k+=2)
-    printf("%c", dir_sector_buffer[dir_sector_offset+k]);
+  for (int k = start; k < (start + len * 2); k += 2)
+    printf("%c", dir_sector_buffer[dir_sector_offset + k]);
 
   start = 0x0E;
   len = 6;
 
-  for (int k = start; k < (start+len*2); k+=2)
-    printf("%c", dir_sector_buffer[dir_sector_offset+k]);
+  for (int k = start; k < (start + len * 2); k += 2)
+    printf("%c", dir_sector_buffer[dir_sector_offset + k]);
 
   start = 0x1C;
   len = 2;
 
-  for (int k = start; k < (start+len*2); k+=2)
-    printf("%c", dir_sector_buffer[dir_sector_offset+k]);
+  for (int k = start; k < (start + len * 2); k += 2)
+    printf("%c", dir_sector_buffer[dir_sector_offset + k]);
 
   printf("\n");
 }
 
 void copy_to_dnamechunk_from_offset(char* dnamechunk, int offset, int numuc2chars)
 {
-  for (int k = 0; k < numuc2chars; k++)
-  {
-    dnamechunk[k] = dir_sector_buffer[dir_sector_offset+offset+k*2];
+  for (int k = 0; k < numuc2chars; k++) {
+    dnamechunk[k] = dir_sector_buffer[dir_sector_offset + offset + k * 2];
   }
 }
 
 void copy_vfat_chars_into_dname(char* dname, int seqnumber)
 {
   // increment char-pointer to the seqnumber string chunk we'll copy across
-  dname = dname + 13 * (seqnumber-1);
+  dname = dname + 13 * (seqnumber - 1);
   copy_to_dnamechunk_from_offset(dname, 0x01, 5);
   dname += 5;
   copy_to_dnamechunk_from_offset(dname, 0x0E, 6);
@@ -1607,28 +1624,26 @@ int fat_readdir(struct m65dirent* d)
     // printf("Found dirent %d %d %d\n",dir_sector,dir_sector_offset,dir_sector_in_cluster);
 
     // Read in all FAT32-VFAT entries to extract out long filenames
-    if (dir_sector_buffer[dir_sector_offset+0x0B] == 0x0F) {
+    if (dir_sector_buffer[dir_sector_offset + 0x0B] == 0x0F) {
       vfatEntry = 1;
       int firstTime = 1;
       int seqnumber;
-      do
-      {
+      do {
         // printf("seq = 0x%02X\n", dir_sector_buffer[dir_sector_offset+0x00]);
         // debug_vfatchunk();
-        int seq = dir_sector_buffer[dir_sector_offset+0x00];
+        int seq = dir_sector_buffer[dir_sector_offset + 0x00];
 
-        if (seq == 0xE5)  // if deleted-entry, then ignore
+        if (seq == 0xE5) // if deleted-entry, then ignore
         {
-          //printf("deleteentry!\n");
-          deletedEntry=1;
+          // printf("deleteentry!\n");
+          deletedEntry = 1;
         }
 
         seqnumber = seq & 0x1F;
 
         // assure there is a null-terminator
-        if (firstTime)
-        {
-          d->d_name[seqnumber*13] = 0;
+        if (firstTime) {
+          d->d_name[seqnumber * 13] = 0;
           firstTime = 0;
         }
 
@@ -1637,33 +1652,31 @@ int fat_readdir(struct m65dirent* d)
         advance_to_next_entry();
 
         // if next dirent is not a vfat entry, break out
-        if (dir_sector_buffer[dir_sector_offset+0x0B] != 0x0F)
+        if (dir_sector_buffer[dir_sector_offset + 0x0B] != 0x0F)
           break;
       } while (seqnumber != 1);
     }
 
     // ignore any vfat files starting with '.' (such as mac osx '._*' metadata files)
     if (vfatEntry && d->d_name[0] == '.') {
-      //printf("._ vfat hide\n");
+      // printf("._ vfat hide\n");
       d->d_name[0] = 0;
       return 0;
     }
 
     // ignored deleted vfat entries too (mac osx '._*' files are marked as deleted entries)
-    if (deletedEntry)
-    {
-      d->d_name[0] = 0;
-      return 0;
-    }
-    
-    // if the DOS 8.3 entry is a deleted-entry, then ignore
-    if (dir_sector_buffer[dir_sector_offset] == 0xE5)
-    {
+    if (deletedEntry) {
       d->d_name[0] = 0;
       return 0;
     }
 
-    int attrib = dir_sector_buffer[dir_sector_offset+0x0B];
+    // if the DOS 8.3 entry is a deleted-entry, then ignore
+    if (dir_sector_buffer[dir_sector_offset] == 0xE5) {
+      d->d_name[0] = 0;
+      return 0;
+    }
+
+    int attrib = dir_sector_buffer[dir_sector_offset + 0x0B];
 
     // if this is the volume-name of the partition, then ignore
     if (attrib == 0x08) {
@@ -1677,54 +1690,49 @@ int fat_readdir(struct m65dirent* d)
       return 0;
     }
 
-
     // Put cluster number in d_ino
     d->d_ino = (dir_sector_buffer[dir_sector_offset + 0x1A] << 0) | (dir_sector_buffer[dir_sector_offset + 0x1B] << 8)
              | (dir_sector_buffer[dir_sector_offset + 0x14] << 16) | (dir_sector_buffer[dir_sector_offset + 0x15] << 24);
 
     // if not vfat-longname, then extract out old 8.3 name
-    if (!vfatEntry)
-    {
-      int namelen=0;
-      int nt_flags = dir_sector_buffer[dir_sector_offset+0x0C];
+    if (!vfatEntry) {
+      int namelen = 0;
+      int nt_flags = dir_sector_buffer[dir_sector_offset + 0x0C];
       int basename_lowercase = nt_flags & 0x08;
       int extension_lowercase = nt_flags & 0x10;
 
       // get the 8-byte filename
       if (dir_sector_buffer[dir_sector_offset]) {
-        for(int i=0;i<8;i++)
-        {
-          if (dir_sector_buffer[dir_sector_offset+i])
-          {
-            int c = dir_sector_buffer[dir_sector_offset+i];
+        for (int i = 0; i < 8; i++) {
+          if (dir_sector_buffer[dir_sector_offset + i]) {
+            int c = dir_sector_buffer[dir_sector_offset + i];
             if (basename_lowercase)
               c = tolower(c);
-            d->d_name[namelen++]=c;
+            d->d_name[namelen++] = c;
           }
         }
-        while(namelen&&d->d_name[namelen-1]==' ') namelen--;
+        while (namelen && d->d_name[namelen - 1] == ' ')
+          namelen--;
       }
       // get the 3-byte extension
-      if (dir_sector_buffer[dir_sector_offset+8]&&dir_sector_buffer[dir_sector_offset+8]!=' ') {
-        d->d_name[namelen++]='.';
-        for(int i=0;i<3;i++)
-        {
-          if (dir_sector_buffer[dir_sector_offset+8+i])
-          {
-            int c = dir_sector_buffer[dir_sector_offset+8+i];
+      if (dir_sector_buffer[dir_sector_offset + 8] && dir_sector_buffer[dir_sector_offset + 8] != ' ') {
+        d->d_name[namelen++] = '.';
+        for (int i = 0; i < 3; i++) {
+          if (dir_sector_buffer[dir_sector_offset + 8 + i]) {
+            int c = dir_sector_buffer[dir_sector_offset + 8 + i];
             if (extension_lowercase)
               c = tolower(c);
-            d->d_name[namelen++]=c;
+            d->d_name[namelen++] = c;
           }
         }
-        while(namelen&&d->d_name[namelen-1]==' ') namelen--;
+        while (namelen && d->d_name[namelen - 1] == ' ')
+          namelen--;
       }
-      d->d_name[namelen]=0;
+      d->d_name[namelen] = 0;
     }
 
     if (dirent_raw && d->d_name[0])
-      dump_bytes(0,"dirent raw",&dir_sector_buffer[dir_sector_offset],32);
-
+      dump_bytes(0, "dirent raw", &dir_sector_buffer[dir_sector_offset], 32);
 
     d->d_filelen = (dir_sector_buffer[dir_sector_offset + 0x1C] << 0) | (dir_sector_buffer[dir_sector_offset + 0x1D] << 8)
                  | (dir_sector_buffer[dir_sector_offset + 0x1E] << 16) | (dir_sector_buffer[dir_sector_offset + 0x1F] << 24);
@@ -2001,8 +2009,7 @@ unsigned int find_contiguous_clusters(unsigned int total_clusters)
   return start_cluster;
 }
 
-typedef struct _llist
-{
+typedef struct _llist {
   void* item;
   struct _llist* next;
 } llist;
@@ -2010,8 +2017,7 @@ typedef struct _llist
 void llist_free(llist* lstitem)
 {
   llist* next;
-  while (lstitem != NULL)
-  {
+  while (lstitem != NULL) {
     free(lstitem->item);
     next = lstitem->next;
     free(lstitem);
@@ -2026,21 +2032,18 @@ llist* llist_new(void)
   return lst;
 }
 
-void llist_add(llist* lst, void* item, int compare(void *, void*))
+void llist_add(llist* lst, void* item, int compare(void*, void*))
 {
-  if (lst->item == NULL)
-  {
+  if (lst->item == NULL) {
     lst->item = item;
     return;
   }
 
   llist* prev = NULL;
 
-  while (lst != NULL)
-  {
+  while (lst != NULL) {
     // we found a home for it?
-    if (compare(lst->item, item) > 0)
-    {
+    if (compare(lst->item, item) > 0) {
       llist* mvlst = llist_new();
       mvlst->item = lst->item;
       mvlst->next = lst->next;
@@ -2063,8 +2066,7 @@ int compare_dirents(void* s, void* d)
   struct m65dirent* src = (struct m65dirent*)s;
   struct m65dirent* dest = (struct m65dirent*)d;
   // both dirs?
-  if ((dest->d_attr & 0x10) && (src->d_attr & 0x10))
-  {
+  if ((dest->d_attr & 0x10) && (src->d_attr & 0x10)) {
     // compare filenames
     return stricmp(src->d_name, dest->d_name);
   }
@@ -2087,8 +2089,7 @@ int read_direntries(llist* lst, char* path)
     return 0;
   }
   // printf("Opened directory, dir_sector=%d (absolute sector = %d)\n",dir_sector,partition_start+dir_sector);
-  while (!fat_readdir(&de))
-  {
+  while (!fat_readdir(&de)) {
     struct m65dirent* denew = (struct m65dirent*)malloc(sizeof(struct m65dirent));
     memcpy(denew, &de, sizeof(struct m65dirent));
     llist_add(lst, denew, compare_dirents);
@@ -2099,8 +2100,7 @@ int read_direntries(llist* lst, char* path)
 
 int contains_dir(llist* lst, char* path)
 {
-  while (lst != NULL)
-  {
+  while (lst != NULL) {
     struct m65dirent* itm = (struct m65dirent*)lst->item;
     if (itm->d_attr & 0x10 && strcmp(itm->d_name, path) == 0)
       return 1;
@@ -2118,65 +2118,54 @@ int is_match(char* line, char* pattern)
 {
   int wildcard = 0;
 
-  do
-  {
-    if ((*pattern == *line) || (*pattern == '?'))
-    {
+  do {
+    if ((*pattern == *line) || (*pattern == '?')) {
       line++;
       pattern++;
     }
-    else if (*pattern == '*')
-    {
-      if (*(++pattern) == '\0')
-      {
+    else if (*pattern == '*') {
+      if (*(++pattern) == '\0') {
         return 1;
       }
       wildcard = 1;
     }
-    else if (wildcard)
-    {
-      if (*line == *pattern)
-      {
+    else if (wildcard) {
+      if (*line == *pattern) {
         wildcard = 0;
         line++;
         pattern++;
       }
-      else
-      {
+      else {
         line++;
       }
-    } 
-    else
-    {
+    }
+    else {
       return 0;
     }
   } while (*line);
 
-  if (*pattern == '\0')
-  {
+  if (*pattern == '\0') {
     return 1;
   }
-  else
-  {
+  else {
     return 0;
   }
 }
 
 void show_local_directory(char* searchpattern)
 {
-  DIR *d;
-  struct dirent *dir;
+  DIR* d;
+  struct dirent* dir;
 
   // list directories first
   d = opendir(".");
   if (d) {
-    while ((dir = readdir(d)) != NULL ) {
+    while ((dir = readdir(d)) != NULL) {
       if (searchpattern && !is_match(dir->d_name, searchpattern))
         continue;
 
       struct stat file_stats;
-      if (!stat(dir->d_name, & file_stats))
-      {
+      if (!stat(dir->d_name, &file_stats)) {
         if (S_ISDIR(file_stats.st_mode))
           printf("       <DIR> %s\n", dir->d_name);
       }
@@ -2187,13 +2176,12 @@ void show_local_directory(char* searchpattern)
   // list files next
   d = opendir(".");
   if (d) {
-    while ((dir = readdir(d)) != NULL ) {
+    while ((dir = readdir(d)) != NULL) {
       if (searchpattern && !is_match(dir->d_name, searchpattern))
         continue;
 
       struct stat file_stats;
-      if (!stat(dir->d_name, & file_stats))
-      {
+      if (!stat(dir->d_name, &file_stats)) {
         if (!S_ISDIR(file_stats.st_mode)) {
           if (dir->d_name[0] && file_stats.st_size >= 0)
             printf("%12d %s\n", (int)file_stats.st_size, dir->d_name);
@@ -2249,8 +2237,7 @@ int show_directory(char* path)
       searchterm = path;
 
     llist* cur = lst_dirents;
-    while (cur != NULL)
-    {
+    while (cur != NULL) {
       struct m65dirent* itm = (struct m65dirent*)cur->item;
 
       if (searchterm && !is_match(itm->d_name, searchterm)) {
@@ -2286,11 +2273,8 @@ int check_file_system_access(void)
 
 int read_int32_from_offset_in_buffer(int offset)
 {
-  int val =
-    (dir_sector_buffer[offset]<<0)
-    |(dir_sector_buffer[offset+1]<<8)
-    |(dir_sector_buffer[offset+2]<<16)
-    |(dir_sector_buffer[offset+3]<<24);
+  int val = (dir_sector_buffer[offset] << 0) | (dir_sector_buffer[offset + 1] << 8) | (dir_sector_buffer[offset + 2] << 16)
+          | (dir_sector_buffer[offset + 3] << 24);
 
   return val;
 }
@@ -2301,19 +2285,16 @@ void show_clustermap(void)
   int previous_clustermap_sector = 0;
   int abs_fat1_sector = partition_start + fat1_sector;
 
-  for (int clustermap_idx = clustermap_start; clustermap_idx < clustermap_end; clustermap_idx++)
-  {
-    int clustermap_sector = abs_fat1_sector + (clustermap_idx*4) / 512;
-    int clustermap_offset = (clustermap_idx*4) % 512;
+  for (int clustermap_idx = clustermap_start; clustermap_idx < clustermap_end; clustermap_idx++) {
+    int clustermap_sector = abs_fat1_sector + (clustermap_idx * 4) / 512;
+    int clustermap_offset = (clustermap_idx * 4) % 512;
 
-    //printf("clustermap_sector = %d\nclustermap_offset=%d\n", clustermap_sector, clustermap_offset);
+    // printf("clustermap_sector = %d\nclustermap_offset=%d\n", clustermap_sector, clustermap_offset);
 
     // do we need to read in the next sector?
-    if (clustermap_sector != previous_clustermap_sector)
-    {
-      int retVal=read_sector(clustermap_sector,dir_sector_buffer, CACHE_YES, 0);
-      if (retVal)
-      {
+    if (clustermap_sector != previous_clustermap_sector) {
+      int retVal = read_sector(clustermap_sector, dir_sector_buffer, CACHE_YES, 0);
+      if (retVal) {
         fprintf(stderr, "Failed to read next sector(%d)\n", clustermap_sector);
         return;
       }
@@ -2329,24 +2310,22 @@ void show_clustermap(void)
 void show_cluster(void)
 {
   char str[50];
-  int abs_cluster2_sector = partition_start + first_cluster_sector + (cluster_num-2)*sectors_per_cluster;
+  int abs_cluster2_sector = partition_start + first_cluster_sector + (cluster_num - 2) * sectors_per_cluster;
 
-  for (int idx = 0; idx < sectors_per_cluster; idx++)
-  {
+  for (int idx = 0; idx < sectors_per_cluster; idx++) {
     read_sector(abs_cluster2_sector + idx, dir_sector_buffer, CACHE_YES, 0);
     sprintf(str, "Sector %d:\n", abs_cluster2_sector + idx);
-    dump_bytes(0,str,dir_sector_buffer,512);
+    dump_bytes(0, str, dir_sector_buffer, 512);
   }
 }
 
 void dump_sectors(void)
 {
   FILE* fsave = fopen(secdump_file, "wb");
-  for (int sector = secdump_start; sector < (secdump_start+secdump_count); sector++)
-  {
+  for (int sector = secdump_start; sector < (secdump_start + secdump_count); sector++) {
     read_sector(sector, dir_sector_buffer, CACHE_YES, 0);
     fwrite(dir_sector_buffer, 1, 512, fsave);
-    printf("\rSaving... (%d%%)", (sector-secdump_start)*100/secdump_count);
+    printf("\rSaving... (%d%%)", (sector - secdump_start) * 100 / secdump_count);
   }
   fclose(fsave);
   printf("\rSaved to file \"%s\".         \n", secdump_file);
@@ -2359,11 +2338,10 @@ void restore_sectors(void)
   int secrestore_count = st.st_size / 512;
 
   FILE* fload = fopen(secrestore_file, "rb");
-  for (int sector = secrestore_start; sector < (secrestore_start+secrestore_count); sector++)
-  {
+  for (int sector = secrestore_start; sector < (secrestore_start + secrestore_count); sector++) {
     fread(dir_sector_buffer, 1, 512, fload);
     write_sector(sector, dir_sector_buffer);
-    printf("\rLoading... (%d%%)", (sector-secrestore_start)*100/secrestore_count);
+    printf("\rLoading... (%d%%)", (sector - secrestore_start) * 100 / secrestore_count);
   }
   fclose(fload);
   printf("\rLoaded file \"%s\" at starting-sector %d.\n", secrestore_file, secrestore_start);
@@ -2383,7 +2361,7 @@ int endswith(char* fname, char* ext)
   char* actual_ext = strrchr(fname, '.');
   if (!ext)
     return 0;
-  
+
   if (strcmp(ext, actual_ext) == 0)
     return 1;
 
@@ -2392,8 +2370,7 @@ int endswith(char* fname, char* ext)
 
 void perform_filehost_read(void)
 {
-  if (username != NULL)
-  {
+  if (username != NULL) {
     log_in_and_get_cookie(username, password);
   }
 
@@ -2405,12 +2382,10 @@ void wrap_upload(char* fname)
   char* d81name = create_d81_for_prg(fname);
   strcpy(fname, d81name);
 
-  if (fname)
-  {
+  if (fname) {
     upload_file(fname, fname);
   }
-  else
-  {
+  else {
     printf("ERROR: Unable to download file from filehost!\n");
   }
 }
@@ -2419,18 +2394,15 @@ void perform_filehost_get(int num)
 {
   char* fname = download_file_from_filehost(num);
 
-  if (endswith(fname, ".prg") || endswith(fname, ".PRG"))
-  {
+  if (endswith(fname, ".prg") || endswith(fname, ".PRG")) {
     char* d81name = create_d81_for_prg(fname);
     strcpy(fname, d81name);
   }
 
-  if (fname)
-  {
+  if (fname) {
     upload_file(fname, fname);
   }
-  else
-  {
+  else {
     printf("ERROR: Unable to download file from filehost!\n");
   }
 }
@@ -2441,9 +2413,10 @@ void show_secinfo(void)
   int abs_fat2_sector = partition_start + fat2_sector;
   int abs_cluster2_sector = partition_start + first_cluster_sector;
 
-  if (!file_system_found) open_file_system();
+  if (!file_system_found)
+    open_file_system();
   printf("\n");
-  printf("  SECTOR : CONTENT\n");    
+  printf("  SECTOR : CONTENT\n");
   printf("  ------   -------\n");
   printf("% 8d : MBR (Master Boot Record)\n", 0);
   printf("% 8d : VBR of 1st Partition\n", partition_start);
@@ -2456,16 +2429,15 @@ void show_secinfo(void)
 void show_vbrinfo(void)
 {
   unsigned char sector[512];
-  if (!file_system_found) open_file_system();
-  if (read_sector(partition_start,sector, CACHE_YES, 0))
-  {
+  if (!file_system_found)
+    open_file_system();
+  if (read_sector(partition_start, sector, CACHE_YES, 0)) {
     printf("Failed to read sector %d...\n", partition_start);
     return;
   }
 
-  printf("OEM Name=\"%c%c%c%c%c%c%c%c\"\n",
-      sector[0x03], sector[0x04], sector[0x05], sector[0x06],
-      sector[0x07], sector[0x08], sector[0x09], sector[0x0A]);
+  printf("OEM Name=\"%c%c%c%c%c%c%c%c\"\n", sector[0x03], sector[0x04], sector[0x05], sector[0x06], sector[0x07],
+      sector[0x08], sector[0x09], sector[0x0A]);
   printf("FAT32 Extended BIOS Parameter Block:\n");
   printf("{\n");
   printf("  DOS 3.31 BPB\n");
@@ -2495,14 +2467,12 @@ void show_vbrinfo(void)
   printf("  Cf. 0x024 for FAT12/FAT16 (Physical Drive Number) = 0x%02X\n", sector[0x40]);
   printf("  Cf. 0x025 for FAT12/FAT16 (Used for various purposes; see FAT12/FAT16) = 0x%02X\n", sector[0x41]);
   printf("  Cf. 0x026 for FAT12/FAT16 (Extended boot signature, 0x29) = 0x%02X\n", sector[0x42]);
-  printf("  Cf. 0x027 for FAT12/FAT16 (Volume ID) = %02X %02X %02X %02X\n", sector[0x43], sector[0x44], sector[0x45], sector[0x46]);
-  printf("  Cf. 0x02B for FAT12/FAT16 (Volume Label) = %c%c%c%c%c%c%c%c%c%c%c\n",
-      sector[0x47], sector[0x48], sector[0x49], sector[0x4a],
-      sector[0x4b], sector[0x4c], sector[0x4d], sector[0x4e],
-      sector[0x4f], sector[0x50], sector[0x51]);
-  printf("  Cf. 0x036 for FAT12/FAT16 (File system type) = %c%c%c%c%c%c%c%c\n",
-      sector[0x52], sector[0x53], sector[0x54], sector[0x55],
-      sector[0x56], sector[0x57], sector[0x58], sector[0x59]);
+  printf("  Cf. 0x027 for FAT12/FAT16 (Volume ID) = %02X %02X %02X %02X\n", sector[0x43], sector[0x44], sector[0x45],
+      sector[0x46]);
+  printf("  Cf. 0x02B for FAT12/FAT16 (Volume Label) = %c%c%c%c%c%c%c%c%c%c%c\n", sector[0x47], sector[0x48], sector[0x49],
+      sector[0x4a], sector[0x4b], sector[0x4c], sector[0x4d], sector[0x4e], sector[0x4f], sector[0x50], sector[0x51]);
+  printf("  Cf. 0x036 for FAT12/FAT16 (File system type) = %c%c%c%c%c%c%c%c\n", sector[0x52], sector[0x53], sector[0x54],
+      sector[0x55], sector[0x56], sector[0x57], sector[0x58], sector[0x59]);
   printf("}\n");
 
   printf("\n");
@@ -2511,37 +2481,36 @@ void show_vbrinfo(void)
 void show_mbrinfo(void)
 {
   unsigned char sector[512];
-  if (!file_system_found) open_file_system();
-  if (read_sector(0,sector, CACHE_YES, 0))
-  {
+  if (!file_system_found)
+    open_file_system();
+  if (read_sector(0, sector, CACHE_YES, 0)) {
     printf("Failed to read sector 0...\n");
     return;
   }
 
-  int pt_ofs=0x1be;
+  int pt_ofs = 0x1be;
   int part_cnt = 0;
 
-  for (int part_id = 0; part_id < 4; part_id++)
-  {
-    if (sector[pt_ofs+0x04] == 0x00) // is partition-type 0? (unused)
+  for (int part_id = 0; part_id < 4; part_id++) {
+    if (sector[pt_ofs + 0x04] == 0x00) // is partition-type 0? (unused)
       continue;
 
     printf("Partition %d\n", part_id);
     printf("-----------\n");
     if (sector[pt_ofs] == 0x80)
       printf("- active/bootable partition\n");
-    printf("- Partition type = 0x%02X\n", sector[pt_ofs+0x04]);
-    int c = sector[pt_ofs+0x03] + ((sector[pt_ofs+0x02] & 0xC0) << 2);
-    int h = sector[pt_ofs+0x02] & 0x3F;
-    int s = sector[pt_ofs+0x01];
+    printf("- Partition type = 0x%02X\n", sector[pt_ofs + 0x04]);
+    int c = sector[pt_ofs + 0x03] + ((sector[pt_ofs + 0x02] & 0xC0) << 2);
+    int h = sector[pt_ofs + 0x02] & 0x3F;
+    int s = sector[pt_ofs + 0x01];
     printf("- First sector chs: cylinder = %d, head = %d, sector = %d\n", c, h, s);
-    c = sector[pt_ofs+0x07] + ((sector[pt_ofs+0x06] & 0xC0) << 2);
-    h = sector[pt_ofs+0x06] & 0x3F;
-    s = sector[pt_ofs+0x05];
+    c = sector[pt_ofs + 0x07] + ((sector[pt_ofs + 0x06] & 0xC0) << 2);
+    h = sector[pt_ofs + 0x06] & 0x3F;
+    s = sector[pt_ofs + 0x05];
     printf("- Last sector chs: cylinder = %d, head = %d, sector = %d\n", c, h, s);
-    printf("- First sector LBA: %d\n", *(unsigned int*)&sector[pt_ofs+0x08]);
-    printf("- Number of sectors: %d\n", *(unsigned int*)&sector[pt_ofs+0x0C]);
-    
+    printf("- First sector LBA: %d\n", *(unsigned int*)&sector[pt_ofs + 0x08]);
+    printf("- Number of sectors: %d\n", *(unsigned int*)&sector[pt_ofs + 0x0C]);
+
     part_cnt++;
     printf("\n");
 
@@ -2689,11 +2658,11 @@ int normalise_long_name(char* long_name, char* short_name, char* dir_name)
 
   // Handle . and .. special cases
   if (!strcmp(long_name, ".")) {
-    bcopy(".          ", short_name, 8+3);
+    bcopy(".          ", short_name, 8 + 3);
     return 0;
   }
   if (!strcmp(long_name, "..")) {
-    bcopy("..         ", short_name, 8+3);
+    bcopy("..         ", short_name, 8 + 3);
     return 0;
   }
 
@@ -2758,7 +2727,7 @@ int normalise_long_name(char* long_name, char* short_name, char* dir_name)
           // store the unmodified short-name (and eventually long-name)?
           fprintf(stderr, "ERROR: Not implemented.\n");
           return -1;
-          //exit(-1);
+          // exit(-1);
         }
       }
     }
@@ -2785,7 +2754,7 @@ int upload_file(char* name, char* dest_name)
   int retVal = 0;
   do {
 
-// #ifdef USE_LFN
+    // #ifdef USE_LFN
     char short_name[8 + 3 + 1];
 
     // Normalise dest_name into 8.3 format.
@@ -2793,7 +2762,7 @@ int upload_file(char* name, char* dest_name)
 
     // Calculate checksum of 8.3 name
     unsigned char lfn_csum = lfn_checksum((unsigned char*)short_name);
-// #endif
+    // #endif
 
     time_t upload_start = time(0);
 
@@ -2818,7 +2787,7 @@ int upload_file(char* name, char* dest_name)
       }
       struct m65dirent de;
       while (!fat_readdir(&de)) {
-        if (!de.d_name[0] && de.d_type==M65DT_FREESLOT) {
+        if (!de.d_name[0] && de.d_type == M65DT_FREESLOT) {
           if (0)
             printf("Found empty slot at dir_sector=%d, dir_sector_offset=%d\n", dir_sector, dir_sector_offset);
 

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -418,7 +418,7 @@ int execute_command(char* cmd)
   else if (parse_command(cmd, "put %s %s", src, dst) == 2) {
     upload_file(src, dst);
   }
-  else if (parse_command(cmd, "wput %s", src) == 1) {
+  else if (parse_command(cmd, "dput %s", src) == 1) {
     wrap_upload(src);
   }
   else if (parse_command(cmd, "del %s", src) == 1) {
@@ -581,7 +581,7 @@ int execute_command(char* cmd)
     printf("lcd [directory] - change current local working directory.\n");
     printf("put <file> [destination name] - upload file to SD card, and optionally rename it destination file.\n");
     printf("get <file> [destination name] - download file from SD card, and optionally rename it destination file.\n");
-    printf("wput <file> - upload .prg file wrapped into a .d81 file\n");
+    printf("dput <file> - upload .prg file wrapped into a .d81 file\n");
     printf("del <file> - delete a file from SD card.\n");
     printf("mkdir <dirname> - create a directory on the SD card.\n");
     printf("cd <dirname> - change directory on the SD card. (aka. 'chdir')\n");

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -44,6 +44,7 @@
 
 #include "m65common.h"
 #include "filehost.h"
+#include "diskman.h"
 #include "dirtymock.h"
 
 #define BOOL int
@@ -2106,9 +2107,27 @@ void poke_sector(void)
   execute_write_queue();
 }
 
+int endswith(char* fname, char* ext)
+{
+  char* actual_ext = strrchr(fname, '.');
+  if (!ext)
+    return 0;
+  
+  if (strcmp(ext, actual_ext) == 0)
+    return 1;
+
+  return 0;
+}
+
 void perform_filehost_get(int num)
 {
   char* fname = download_file_from_filehost(num);
+
+  if (endswith(fname, ".prg") || endswith(fname, ".PRG"))
+  {
+    char* d81name = create_d81_for_prg(fname);
+    strcpy(fname, d81name);
+  }
 
   if (fname)
   {

--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -49,8 +49,6 @@
 #define TRUE 1
 #define FALSE 0
 
-#define DT_FREESLOT 0xff
-
 #define SECTOR_CACHE_SIZE 4096
 int sector_cache_count = 0;
 unsigned char sector_cache[SECTOR_CACHE_SIZE][512];
@@ -190,6 +188,8 @@ int poke_value = 0;
 #define M65DT_REG 1
 #define M65DT_DIR 2
 #define M65DT_UNKNOWN 4
+#define M65DT_FREESLOT 0xff
+
 
 int sd_status_fresh = 0;
 unsigned char sd_status[16];
@@ -1686,6 +1686,8 @@ int fat_readdir(struct m65dirent* d)
       d->d_type = M65DT_UNKNOWN;
     else if (d->d_attr & 0x10)
       d->d_type = M65DT_DIR;
+    else if (d->d_attr == 0 && d->d_name[0] == 0)
+      d->d_type = M65DT_FREESLOT;
     else
       d->d_type = M65DT_REG;
 
@@ -2452,7 +2454,7 @@ int upload_file(char* name, char* dest_name)
       }
       struct m65dirent de;
       while (!fat_readdir(&de)) {
-        if (!de.d_name[0] && de.d_type==DT_FREESLOT) {
+        if (!de.d_name[0] && de.d_type==M65DT_FREESLOT) {
           if (0)
             printf("Found empty slot at dir_sector=%d, dir_sector_offset=%d\n", dir_sector, dir_sector_offset);
 


### PR DESCRIPTION
As my vfat efforts took a tangent in different directions, I thought I better do a pull-request for the work done so far, as I'm worried if I wait till the complete vfat implementation is in, it'll be even larger, and an enormous pain to review.

So, work done so far:

### VFAT
- bringing across my prior vfat logic (for viewing the names of lfn entries)
- enabled Paul's lfn shortname logic, which needs some more tlc before we can make full use of it
- NOTE: I'll finalise vfat stuff in the next PR

### Extra mega65_ftp commands to retrieve files from filehost
- `fh` - lists the files on the filehost (prefacing each item with a numeric index)
- `fhget <idx>` - retrieves the indexed file from the filehost (.prg files are automatically wrapped into a .d81)
- Run mega65_ftp with `-u username -p pwd` args to also access private files on the filehost

### Extra mega65_ftp perks for console-junkies
- `dput <file.prg>` - wraps a local .prg file into a .d81 and then uploads it to the sd-card
- `dir` command now sorts items alphabetically (with directories first, files after)
- `ldir` - list the files in your local pc's current working directory.
- `lcd` - change your local pc's current working-directory
- `lpwd` - print out the path of your local pc's current working-directory
- `dir` and `ldir` commands now support wildcards. E.g., `dir *.ROM`

### Extra mega65_ftp commands for sd-card debugging
- `dirent_raw 0|1` (a debug flag to set to 0 or 1)
- `clustermap <startidx> [<count>]` - show cluster-map entries for specified range.
- `secdump <filename> <startsec> <count>` - dump the specified sector range to a file.
- `secrestore <filename> <startsec>` - restore a dumped file back into the specified sector area.
- `secinfo` - lists the locations of various useful sectors, for easy reference.
- `mbrinfo` - lists the partitions specified in the MBR (sector 0)
- `vbrinfo` - lists the VBR details of the main Mega65 partition
- `poke <sector> <offset> <val>` - poke a value into a sector, at the desired offset.

### More convenience env-vars for developers
The aim of these is to help speed up developer build iterations (all of these are on (1) by default):
- `DO_SMU=0|1` - turn off/on the `git submodule update --init` step within many build targets
- `DO_MKVER=0|1` - turn off/on the auto-generation of the `version.c` file via `gitversion.sh` script
- `DO_STATIC=0|1` - turn off/on the static-linking of libraries (mingw64-windows related only)

E.g., For faster builds, you might want to build with `make DO_SMU=0 DO_MKVER=0 DO_STATIC=0 bin/mega65.ftp.exe` (or add these env-vars into your `~/.bashrc`)

### OpenROMs improvements
- Added extra slowdown for xemu+openroms
- If openrom detected, don't use `g080d` to start the ftp-helper, use `RUN` instead

### Other
- Prevented the `rename` command from renaming a file to an existing file