### PR TITLE
Better handling of new -u argument

### DIFF
--- a/src/tools/m65.c
+++ b/src/tools/m65.c
@@ -1268,7 +1268,7 @@ extern const char* version_string;
 char* test_states[16] = { "START", " SKIP", " PASS", " FAIL", "ERROR", "C#$05", "C#$06", "C#$07", "C#$08", "C#$09", "C#$0A",
   "C#$0B", "C#$0C", "  LOG", " NAME", " DONE" };
 
-char msgbuf[160];
+char msgbuf[160], *endp;
 char testname[160];
 unsigned char inbuf[8192];
 unsigned int failcount;
@@ -1641,7 +1641,11 @@ int main(int argc, char** argv)
       break;
     case 'u':
       unit_test_mode = 1;
-      unit_test_timeout = atoi(optarg);
+      unit_test_timeout = strtol(optarg, &endp, 10);
+      if (*endp != '\0') {
+        fprintf(stderr, "-u option requires a numeric argument\n");
+        exit(-1);
+      }
       if (unit_test_timeout < UT_TIMEOUT) unit_test_timeout = UT_TIMEOUT;
       break;
     default: /* '?' */


### PR DESCRIPTION
If you currently call
`m65 -F -4 -r -u src/tests/test_468.prg`
as before, it will silently not start the program.

Correct call is now:
`m65 -F -4 -r -u 60 src/tests/test_468.prg`

This patch will check if the argument to -u is actually a number, and if not will fail with a error message, so you know what you did wrong.

Just took me 30 min to see my error in the call introduced by my own patch...