### PR TITLE
Fix compilation errors (on Linux).

### DIFF
--- a/src/tools/fpgajtag/fpgajtag.c
+++ b/src/tools/fpgajtag/fpgajtag.c
@@ -811,8 +811,8 @@ char* init_fpgajtag(const char* serialno, const char* serialport, uint32_t file_
           }
       }
       closedir(d);
-#endif
     }
+#endif
   }
 
   if (last_match != -1) {
@@ -822,7 +822,7 @@ char* init_fpgajtag(const char* serialno, const char* serialport, uint32_t file_
     return strdup(last_path);
   }
 
-  printf("id %x from file does not match usb interface\n", file_idcode);
+  fprintf(stderr,"id %x from file does not match usb interface\n", file_idcode);
 
   EXIT();
   return NULL;

--- a/src/tools/readdisk.c
+++ b/src/tools/readdisk.c
@@ -1426,7 +1426,7 @@ int main(int argc, char** argv)
           "         and then log out, and log back in again, or failing that, reboot your computer and try again.\n"
           "\n");
     }
-    res = init_fpgajtag(NULL, NULL, fpga_id);
+    char* res = init_fpgajtag(NULL, NULL, fpga_id);
     if (res != NULL)
       serial_port = res;
   }


### PR DESCRIPTION
Hi,

While compiling the refactor_m65 branch of mega65-tools on Linux, I had some compilation errors to fix.
(lots of warnings remain)

P.S. on the fpgajtag.c fix, I also changed the print of the usb mismatch to stderr. It seemed more logical.

T.