### PR TITLE
feat: test #604 (raster irq not executing twice)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ TESTS=		$(TESTDIR)/ascii.prg \
 		$(TESTDIR)/test_579.prg \
 		$(TESTDIR)/test_585.prg \
 		$(TESTDIR)/test_340.prg \
+		$(TESTDIR)/test_604.prg \
 		$(TESTDIR)/test_mandelbrot.prg \
 		$(TESTDIR)/eth_rxd_test.prg \
 
@@ -284,6 +285,9 @@ $(TESTDIR)/vicii.prg:       $(TESTDIR)/vicii.c $(TESTDIR)/vicii_asm.s $(CC65) $(
 
 $(TESTDIR)/test_290.prg:       $(TESTDIR)/test_290.c $(CC65) $(MEGA65LIBC)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $< $(SRCDIR)/mega65-libc/cc65/src/memory.c $(SRCDIR)/mega65-libc/cc65/src/random.c $(SRCDIR)/mega65-libc/cc65/src/tests.c
+
+$(TESTDIR)/test_604.prg:       $(TESTDIR)/test_604.c $(TESTDIR)/test_604_asm.s $(CC65) $(MEGA65LIBC)
+	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -O -o $*.prg --mapfile $*.map $< $(TESTDIR)/test_604_asm.s $(SRCDIR)/mega65-libc/cc65/src/memory.c $(SRCDIR)/mega65-libc/cc65/src/tests.c
 
 $(TESTDIR)/buffereduart.prg:       $(TESTDIR)/buffereduart.c $(CC65) $(MEGA65LIBC)
 	$(CL65) -I $(SRCDIR)/mega65-libc/cc65/include -Iinclude/ -O -o $*.prg --mapfile $*.map $< $(SRCDIR)/mega65-libc/cc65/src/memory.c $(SRCDIR)/mega65-libc/cc65/src/hal.c $(SRCDIR)/mega65-libc/cc65/src/targets.c

--- a/src/tests/regression-tests.lst
+++ b/src/tests/regression-tests.lst
@@ -10,4 +10,5 @@ test_332.prg    10
 test_454.prg    10
 test_468.prg    10
 test_585.prg    20
+test_604.prg    10
 # END OF FILE

--- a/src/tests/test_604.c
+++ b/src/tests/test_604.c
@@ -1,0 +1,80 @@
+/*
+  Fine raster IRQs (compare registers $d079/$d07a) do not behave as are known
+  from a VIC-II. They compare and set the relevant bit in $d019 both at the 
+  beginning of a raster line as well as at the very end. This leads to odd 
+  effects if the IRQ is acknowledged when still in the line where it was 
+  triggered (eg. if the ack is happening at the beginning of the IRQ handler).
+  The result is the IRQ is triggered twice instead of once (see issue #604).
+
+  This programme tests if the raster IRQ is exactly triggered once per frame.
+*/
+#define ISSUE_NUM 604
+#define ISSUE_NAME "vic-iv raster irq incorrectly triggered twice"
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include <memory.h>
+#include <tests.h>
+
+char msg[80 + 1];
+
+int8_t test_status = -1;
+uint8_t last_frame_counter;
+
+void init(void)
+{
+  // Fast CPU, M65 IO
+  mega65_io_enable();
+
+  // black screen
+  POKE(0xD020, 0);
+  POKE(0xD021, 0);
+}
+
+extern void setup_irq(void);
+
+void main(void)
+{
+  uint8_t frames_to_go = 50;
+  uint8_t cur_frame, last_frame;
+
+  init();
+  printf("%cIssue #%d - %s\n\n", 0x93 /*clrscr*/, ISSUE_NUM, ISSUE_NAME);
+
+  unit_test_setup(ISSUE_NAME, ISSUE_NUM);
+
+  setup_irq();
+
+  last_frame = PEEK(0xD7FA);
+  while (frames_to_go != 0)
+  {
+    cur_frame = PEEK(0xD7FA);
+    if (cur_frame != last_frame)
+    {
+      last_frame = cur_frame;
+      --frames_to_go;
+    }
+  }
+
+  switch (test_status)
+  {
+    case -1:
+      snprintf(msg, 80, "irq handler was not able to execute");
+      unit_test_fail(msg);
+      break;
+    case 0:
+      snprintf(msg, 80, "raster irq working as expected");
+      unit_test_ok(msg);
+      break;
+    case 1:
+      snprintf(msg, 80, "raster irq behaviour wrong, called multiple times per frame");
+      unit_test_fail(msg);
+      break;
+    default:
+      snprintf(msg, 80, "internal error in test case");
+      unit_test_fail(msg);
+  }
+
+  unit_test_report(ISSUE_NUM, 0, TEST_DONEALL);
+}

--- a/src/tests/test_604_asm.s
+++ b/src/tests/test_604_asm.s
@@ -1,0 +1,68 @@
+	.setcpu		"4510"
+	.export _setup_irq
+	.import _test_status
+	
+_setup_irq:
+  sei
+	;; disable cia irqs
+  lda #$7f
+	sta $dc0d
+	sta $dd0d
+  ;; ack cia irqs potentially pending
+	lda $dc0d
+	lda $dd0d
+
+  ;; disable RSTDELEN
+  lda #%01000000
+	trb $d05d
+	;; raster irq compare
+	lda #$60
+	sta $d079
+  ;; enable physical rasters
+  lda #%10000111
+	trb $d07a
+  ;; enable raster irq
+	lda #$01
+	sta $d01a
+  ;; ack raster irq potentially pending
+	lda #$ff
+	sta $d019
+
+  ;; setup irq vector
+	lda #<_irq_handler
+	sta $0314
+	lda #>_irq_handler
+	sta $0315
+
+  cli
+	rts
+
+_irq_handler:
+	lda #$ff
+	sta $d019
+
+	lda _test_status
+	bmi first_frame
+
+	;; current frame counter
+	lda $d7fa
+	cmp last_frame_counter
+	bne exit
+
+	;; we are triggered the second time during current frame_counter -> fail
+	lda #$01
+	sta _test_status
+	jmp exit
+
+first_frame:
+	lda #$00
+	sta _test_status
+
+exit:
+	lda $d7fa
+	sta last_frame_counter
+	jmp $ea31
+
+
+last_frame_counter:
+  .word $0000


### PR DESCRIPTION
This PR adds a new test for issue #604
The test installs a raster irq handler, acknowledging the irq directly in the irq handler. It tests whether the raster irq handler gets called once or multiple times per frame. The fix for #604 ensures the raster irq will only be triggered once per frame.