### PR TITLE
Support being given the FAT32 partition as SD card device.

### DIFF
--- a/src/tools/mega65_ftp.c
+++ b/src/tools/mega65_ftp.c
@@ -207,7 +207,7 @@ unsigned char* sd_read_buffer = NULL;
 int sd_read_offset = 0;
 
 int file_system_found = 0;
-unsigned int partition_start = 0; // The absolute sector location of the start of the partition (in units of sectors)
+unsigned int partition_start = 0xffffffff; // The absolute sector location of the start of the partition (in units of sectors)
 unsigned int partition_size = 0;
 unsigned char sectors_per_cluster = 0;
 unsigned int sectors_per_fat = 0;
@@ -1459,6 +1459,14 @@ int open_file_system(void)
       }
     }
 
+    if (partition_start == 0xffffffff && direct_sdcard_device) {
+      if (strncmp((const char*)&mbr[0x52], "FAT32", 5) == 0) {
+        partition_start = 0;
+        partition_size = mbr[0x20] + (mbr[0x21] << 8) + (mbr[0x22] << 16) + (mbr[0x23] << 24);
+        printf("Device is FAT32 partition, size=%d MB\n", partition_size / 2048);
+      }
+    }
+
     if (syspart_start && !nosys) {
       // Ok, so we know where the partition starts, so now find the FATs
       if (read_sector(syspart_start, syspart_sector0, CACHE_YES, 0)) {
@@ -1490,7 +1498,7 @@ int open_file_system(void)
       syspart_service_slotdir_sectors = syspart_sector0[0x2e] + (syspart_sector0[0x2f] << 8);
     }
 
-    if (!partition_start) {
+    if (partition_start == 0xffffffff) {
       retVal = -1;
       break;
     }


### PR DESCRIPTION
That means you can give either the whole SD card (`/dev/sdN` or `/dev/diskN`) or the FAT32 partition directly (`/dev/sdNX` or `/dev/diskNsX`):

If no FAT32 partition is found in the MBR, it checks for the FAT32 file system signature and if that is present, uses the whole device file as the FAT32 partition.

Since the partition can now start at 0, I've changed the value for "no partition found" to 0xffffffff.