### PR TITLE
M1 and universal builds for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ bin/mega65_ftp*
 bin/m65dbg*
 bin/romdiff*
 
+bin/*.osx
+bin/*.dSYM
+
 bin/etherload
 bin/giftotiles
 bin/pngprepare
@@ -20,6 +23,11 @@ src/tools/ftphelper.c
 src/tools/ascii_font.c
 
 gtest/bin/*
+
+conan.lock
+conanbuildinfo*
+conaninfo.txt
+graph_info.json
 
 *~
 #*#

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       os: osx
       osx_image: xcode13.1
       before_script:
+      - brew config
+      - brew update
       - HOMEBREW_NO_AUTO_UPDATE=1 brew install conan cc65 p7zip
       - conan --version
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       os: osx
       osx_image: xcode13.1
       before_script:
-      - HOMEBREW_NO_AUTO_UPDATE=1 brew install libusb libpng zlib cc65 p7zip
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install conan cc65 p7zip
       script:
       - make USE_LOCAL_CC65=1 arcmac
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ matrix:
   include:
     - name: MacOS native compilation
       os: osx
-      osx_image: xcode13.1
+      osx_image: xcode14.1
       before_script:
-      - brew config
-      - brew update
       - HOMEBREW_NO_AUTO_UPDATE=1 brew install conan cc65 p7zip
       - conan --version
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
       osx_image: xcode13.1
       before_script:
       - HOMEBREW_NO_AUTO_UPDATE=1 brew install conan cc65 p7zip
+      - conan --version
       script:
       - make USE_LOCAL_CC65=1 arcmac
       before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 .SUFFIXES: .bin .prg
 .PRECIOUS:	%.ngd %.ncd %.twx vivado/%.xpr bin/%.bit bin/%.mcs bin/%.M65 bin/%.BIN
 
+OS := $(shell uname)
+ifeq ($(OS), Darwin)
 include conanbuildinfo_macos_intel.mak
 include conanbuildinfo_macos_arm.mak
+endif
 
 #COPT=	-Wall -g -std=gnu99 -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope
 #CC=	clang

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,6 @@ CL65ONLY=  $(CC65_PREFIX)cl65
 CC65_DEPEND=
 
 LIBUSBINC= `pkg-config --cflags libusb-1.0` -I/usr/include/libusb-1.0 -I/opt/local/include/libusb-1.0 -I/usr/local/Cellar/libusb/1.0.18/include/libusb-1.0/
-MACLIBUSBLINK= `pkg-config --variable libdir libusb-1.0`/libusb-1.0.a -framework Security
-MACLIBPNGLINK= `pkg-config --variable libdir libpng`/libpng.a
 
 CBMCONVERT=	cbmconvert/cbmconvert
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ endif
 #COPT=	-Wall -g -std=gnu99 -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope
 #CC=	clang
 COPT=	-Wall -g -std=gnu99
-# -I/usr/local/Cellar/libusb/1.0.23/include/libusb-1.0/ -L/usr/local/Cellar/libusb/1.0.23/lib/libusb-1.0/
 CC=	gcc
 CXX=g++
 #MACCOPT=$(COPT) -framework CoreFoundation -framework IOKit

--- a/conan/profile_macos_10.14_intel
+++ b/conan/profile_macos_10.14_intel
@@ -1,0 +1,5 @@
+[settings]
+os=Macos
+os.version=10.14
+arch=x86_64
+build_type=RelWithDebInfo

--- a/conan/profile_macos_11_arm
+++ b/conan/profile_macos_11_arm
@@ -1,0 +1,5 @@
+[settings]
+os=Macos
+os.version=11.0
+arch=armv8
+build_type=RelWithDebInfo

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,9 @@
+[requires]
+libusb/1.0.26
+libpng/1.6.39
+
+[options]
+*:shared=False
+
+[generators]
+make


### PR DESCRIPTION
This PR adds support for universal binaries to the Makefile. 3rd party libraries are fetched via Conan. Homebrew fetched packages can't be used easily for multi-arch binaries.