### PR TITLE
etherload and mega65_ftp supporting any ip address #178

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else
 ifeq (, $(shell which conan))
 $(info WARNING: Found $(WINCC), but no conan executable found in PATH, can't build windows binaries)
 else
-WINCOPT:=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1 -mno-sse3 -march=x86-64
+WINCOPT:=$(COPT) -DWINDOWS -D__USE_MINGW_ANSI_STDIO=1 -D_WIN32_WINNT=0x0600 -DWINVER=0x0600 -mno-sse3 -march=x86-64
 endif # conan detection
 endif # mingw-w64 detection
 endif # Linux
@@ -783,10 +783,12 @@ MEGA65FTP_SRC=	$(TOOLDIR)/mega65_ftp.c \
 		$(TOOLDIR)/diskman.c \
 		$(TOOLDIR)/bit2mcs.c \
 		$(TOOLDIR)/etherload/etherload_common.c \
+		$(TOOLDIR)/etherload/ethlet_set_ip_address.c \
 		$(TOOLDIR)/etherload/ethlet_dma_load.c \
 		$(TOOLDIR)/etherload/ethlet_all_done_basic2.c
 
-MEGA65FTP_HDR=	$(TOOLDIR)/etherload/ethlet_dma_load_map.h \
+MEGA65FTP_HDR=	$(TOOLDIR)/etherload/ethlet_set_ip_address_map.h \
+		$(TOOLDIR)/etherload/ethlet_dma_load_map.h \
 		$(TOOLDIR)/etherload/ethlet_all_done_basic2_map.h
 
 # Gives two targets of:
@@ -806,7 +808,7 @@ $(BINDIR)/mega65_ftp.static: $(MEGA65FTP_SRC) $(MEGA65FTP_HDR) $(TOOLDIR)/versio
 	$(CC) $(COPT) -Iinclude $(LIBUSBINC) -mno-sse3 -o $(BINDIR)/mega65_ftp.static $(MEGA65FTP_SRC) $(TOOLDIR)/version.c ncurses/lib/libncurses.a readline/libreadline.a readline/libhistory.a -ltermcap -DINCLUDE_BIT2MCS
 
 $(BINDIR)/mega65_ftp.exe: win_build_check $(MEGA65FTP_SRC) $(MEGA65FTP_HDR) $(TOOLDIR)/version.c include/*.h conan_win Makefile
-	$(WINCC) $(WINCOPT) -D_FILE_OFFSET_BITS=64 -g -Wall -Iinclude $(LIBUSBINC) -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(MEGA65FTP_SRC) $(TOOLDIR)/version.c -lusb-1.0 $(BUILD_STATIC) -lwsock32 -lws2_32 -lz -Wl,-Bdynamic -DINCLUDE_BIT2MCS
+	$(WINCC) $(WINCOPT) -D_FILE_OFFSET_BITS=64 -g -Wall -Iinclude $(LIBUSBINC) -I$(TOOLDIR)/fpgajtag/ -o $(BINDIR)/mega65_ftp.exe $(MEGA65FTP_SRC) $(TOOLDIR)/version.c -lusb-1.0 $(BUILD_STATIC) -lwsock32 -lws2_32 -liphlpapi -lz -Wl,-Bdynamic -DINCLUDE_BIT2MCS
 
 $(BINDIR)/mega65_ftp_intel.osx: $(MEGA65FTP_SRC) $(MEGA65FTP_HDR) $(TOOLDIR)/version.c include/*.h conan_mac Makefile
 	$(CC) $(MACINTELCOPT) -D__APPLE__ -D_FILE_OFFSET_BITS=64 -o $@ -Iinclude $(MEGA65FTP_SRC) $(TOOLDIR)/version.c -lpthread -lreadline -DINCLUDE_BIT2MCS
@@ -853,13 +855,15 @@ $(BINDIR)/m65dbg.exe:	win_build_check $(M65DBG_SOURCES) $(M65DBG_HEADERS) conan_
 ##
 ETHERLOAD_SOURCES=	$(TOOLDIR)/etherload/etherload.c \
 			$(TOOLDIR)/etherload/etherload_common.c \
+			$(TOOLDIR)/etherload/ethlet_set_ip_address.c \
 			$(TOOLDIR)/etherload/ethlet_dma_load.c \
 			$(TOOLDIR)/etherload/ethlet_all_done_basic2.c \
 			$(TOOLDIR)/etherload/ethlet_all_done_basic65.c \
 			$(TOOLDIR)/etherload/ethlet_all_done_jump.c \
 			$(TOOLDIR)/logging.c \
 			$(TOOLDIR)/version.c
-ETHERLOAD_HEADERS=	$(TOOLDIR)/etherload/ethlet_dma_load_map.h \
+ETHERLOAD_HEADERS=	$(TOOLDIR)/etherload/ethlet_set_ip_address_map.h \
+			$(TOOLDIR)/etherload/ethlet_dma_load_map.h \
 			$(TOOLDIR)/etherload/ethlet_all_done_basic2_map.h \
 			$(TOOLDIR)/etherload/ethlet_all_done_basic65_map.h \
 			$(TOOLDIR)/etherload/ethlet_all_done_jump_map.h
@@ -882,4 +886,4 @@ $(BINDIR)/etherload_arm.osx:	$(ETHERLOAD_SOURCES) $(ETHERLOAD_HEADERS) conan_mac
 	$(CC) $(MACARMCOPT) -Iinclude -o $@ $(ETHERLOAD_SOURCES) $(ETHERLOAD_INCLUDES) $(ETHERLOAD_LIBRARIES)
 
 $(BINDIR)/etherload.exe:	win_build_check $(ETHERLOAD_SOURCES) $(ETHERLOAD_HEADERS) include/*.h conan_win Makefile
-	$(WINCC) $(WINCOPT) -o $(BINDIR)/etherload $(ETHERLOAD_SOURCES) $(ETHERLOAD_INCLUDES) $(ETHERLOAD_LIBRARIES) -lwsock32
+	$(WINCC) $(WINCOPT) -o $(BINDIR)/etherload $(ETHERLOAD_SOURCES) $(ETHERLOAD_INCLUDES) $(ETHERLOAD_LIBRARIES) -lwsock32 -liphlpapi -lws2_32

--- a/include/etherload_common.h
+++ b/include/etherload_common.h
@@ -16,7 +16,7 @@ typedef int (*is_duplicate_callback_t)(uint8_t *payload, int len, uint8_t *cmp_p
 typedef int (*embed_packet_seq_callback_t)(uint8_t *payload, int len, int seq_num);
 typedef int (*timeout_handler_callback_t)();
 
-int etherload_init(const char *broadcast_address);
+int etherload_init(const char *target_ip_address, const char *broadcast_ip_address);
 void etherload_finish(void);
 
 void ethl_setup_dmaload(void);

--- a/src/tools/etherload/ethlet_all_done_basic2.a65
+++ b/src/tools/etherload/ethlet_all_done_basic2.a65
@@ -137,6 +137,19 @@ restore_write_protection:
 	sta $d641
 	clv
 
+	; bank in c65 kernel rom to make available init_palette routine
+	lda #$80
+	ldx #$8d
+	ldy #$00
+	ldz #$83
+	map
+	eom
+
+	; reset palette
+	lda #$00
+	sta $d070 ; reset palette indices
+	jsr $e027 ; init_palette
+
 	; turn off mapping of upper 32kb region
 	lda #$80
 	ldx #$8d
@@ -174,6 +187,9 @@ restore_write_protection:
 	; disable seam
 	lda #$d7
 	trb $d054
+
+	; disable SPRENV400
+	sta $d076	
 
 	; 40 column mode normal C64 screen
 	lda #$00

--- a/src/tools/etherload/ethlet_all_done_basic65.a65
+++ b/src/tools/etherload/ethlet_all_done_basic65.a65
@@ -198,6 +198,13 @@ finalize:
 	lda #$d7
 	trb $d054
 
+	; reset palette selections
+	lda #$00
+	sta $d070
+
+	; disable SPRENV400
+	sta $d076
+	
 	; 40 column mode normal C64 screen
 	lda #$00
 	sta $d031

--- a/src/tools/etherload/ethlet_set_ip_address.a65
+++ b/src/tools/etherload/ethlet_set_ip_address.a65
@@ -1,5 +1,5 @@
-; This little helper contains the code to be transferred along with the
-; data in the Ethernet frames sent by etherload.
+; Ethlet to set a static ip address for etherload
+; ip address will be stored in colour ram after the ETHLOAD.M65 code at $FF87FFC 
 
 	; Routine sits at beginning of UDP payload in the Ethernet buffer
 	; mapped at $6800
@@ -9,62 +9,54 @@
 	; UDP header:       8 bytes
 	.org $6800 + 2 + 14 + 20 + 8
 
+    .alias pkt_len      ip_address + 4 - $6802
+
 entry:
-	; Routine that copies packet contents by DMA
-	lda #$00 ; Dummy LDA #$xx for signature detection
 
-	; Debug: wait for $d610 key press on each data frame
+	; Dummy inc $d020 jmp *-3 routine for debugging
+;	lda #$00
+;	inc $d020
 ;*
-;	inc $0427
-;	lda $d610
-;	beq -
-;	sta $d610
+;	jmp -
 
+	; Production routine that skips the jmp *-3 loop
+	lda #$00
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+
+	; Enable mega65 I/O personality
 	lda #$47
 	sta $d02f
 	lda #$53
 	sta $d02f
 
-	; 5a. Wait for TX ready
+    ; we expect the ETHLOAD.M65 code still to be mapped at $8000
+    ; ip address shall thus be put at $80fc
+    ldx #$03
+*	lda ip_address,x
+    sta $80fc,x
+    dex
+    bpl -
+
+	; Wait for TX ready
 *
 	lda $d6e1
 	and #$10
 	beq -
 
-rom_write_enable:
-	lda #$00
-	beq copy_data
-	lda #$02
-	sta $d641
-	clv
-
-copy_data:
-	sta $d707 ; trigger in-line DMA
-	.byte $80, $ff ; SRC MB is $FF
-	.byte $81
-dest_mb:
-	.byte $00      ; Destination MB
-	.byte $00      ; DMA end of option list
-	.byte $04      ; copy + chained
-byte_count:
-	.word $0400    ; DMA byte count
-	.word $e900    ; DMA source address (bottom 16 bits)
-	.byte $8d      ; DMA source bank and flags ($8x = enable I/O)
-dest_address:
-	.word $1000    ; DMA destination address (bottom 16 bits)
-dest_bank:
-	.byte $00      ; DMA destination bank
-	.byte $00      ; DMA sub command
-	.word $0000    ; DMA modulo (ignored)
-
 	; Use chained DMA to copy packet to TX buffer, and then send it
 	; so that we can get what will effectively be an ACK to each
 	; packet received by the MEGA65.
+	sta $d707 ; trigger in-line DMA
 	.byte $80, $ff
 	.byte $81, $ff
 	.byte $00      ; DMA end of option list
 	.byte $04      ; DMA copy, chained
-	.word $0600    ; DMA byte count 
+	.word pkt_len  ; DMA byte count 
 	.word $e802    ; DMA source address (bottom 16 bits) 
 	.byte $8d      ; DMA source bank and flags ($8x = I/O enabled)
 	.word $e800    ; DMA destination address (bottom 16 bits)
@@ -113,9 +105,9 @@ dest_bank:
 	sta $23
 
 	; Set packet len
-	lda #$2a
+	lda #<pkt_len
 	sta $d6e2
-	lda #$05
+	lda #>pkt_len
 	sta $d6e3
 
 	; swap src/dst ip addresses (no need to recalc ip chks as this change won't alter it)
@@ -141,10 +133,8 @@ dest_bank:
 	tab
 
 	; Return to packet wait loop
-	rts
+    rts
 
-	.advance $68fe, $00
-seq_num:
-	.advance $6900, $00
-data:
-	.advance $6d2c, $00 ; packet is $500 (1280) bytes + $2c bytes headers
+ip_address:
+	.byte 0, 0, 0, 0
+

--- a/src/utilities/remotesd_eth.c
+++ b/src/utilities/remotesd_eth.c
@@ -156,6 +156,7 @@ uint16_t seq_num;
 uint32_t write_cache_offset;
 
 EUI48 mac_local;
+IPV4 ip_local;
 uint8_t ip_addr_set = 0;
 
 uint16_t ip_id = 0;
@@ -218,6 +219,8 @@ void init(void)
   POKE(0xD689, PEEK(0xD689) | 128); // Enable SD card buffers instead of Floppy buffer
 
   init_screen();
+
+  lcopy(0xFF87FFC, (unsigned long)&ip_local.b[0], sizeof(IPV4));
 
   sector_reading = 0;
   sector_buffered = 0;
@@ -798,7 +801,7 @@ void get_new_job()
           sizeof(FTP_PKT) + sizeof(WRITE_SECTOR_JOB));
 
       if (ip_addr_set == 0) {
-        if (recv_buf.ftp.destination.b[3] != 65) {
+        if (recv_buf.ftp.destination.d != ip_local.d) {
           continue;
         }
       }


### PR DESCRIPTION
This changes the -I parameter of etherload and mega65_ftp so that it won't represent the network broadcast ip address but instead the ip address to be assigned to the MEGA65 for this connection. This allows to use any ip address for the MEGA65, not just x.y.z.65 as was the case before.