### PR TITLE
Add 2 needed dependencies for building on arm64 (raspberry pi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Releases are made via a release-* branch, and you can find those on Filehost, to
 To build on e.g. Debian Linux, install the following packages:
 
 ```
-sudo apt-get install build-essential pkg-config git gh wget python3 cc65 sshpass unzip imagemagick p7zip-full libgtest-dev libgmock-dev libreadline-dev libtinfo5 libcairo2-dev
+sudo apt-get install build-essential pkg-config git gh wget python3 cc65 sshpass unzip imagemagick p7zip-full libgtest-dev libgmock-dev libreadline-dev libtinfo5 libcairo2-dev libusb-1.0-0-dev libgif-dev
 ```
 
 After cloning the repository, enter its directory and call


### PR DESCRIPTION
Added libusb-1.0-0-dev and libgif-dev as linux dependencies. These are listed in the section for cross-building to Windows, but I also found they were needed when installing to the latest Raspberry Pi OS.