### PR TITLE
Replace /bin/bash with /usr/bin/env bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 .SUFFIXES: .bin .prg
 .PRECIOUS:	%.ngd %.ncd %.twx vivado/%.xpr bin/%.bit bin/%.mcs bin/%.M65 bin/%.BIN

--- a/src/gitversion.sh
+++ b/src/gitversion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 shorten_name () {
   name=$1

--- a/src/tests/regression-test.sh
+++ b/src/tests/regression-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT="$(readlink --canonicalize-existing "$0")"
 SCRIPTPATH="$(dirname "${SCRIPT}")"

--- a/src/tests/runTests.sh
+++ b/src/tests/runTests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # very simple test runner: find all *.prg files in the current directory
 # and run them.


### PR DESCRIPTION
NixOS cannot use `/bin/bash` without significant work, but works fine with `/usr/bin/env bash` so long as bash is installed. This _shouldn't_ break Ubuntu