### PR TITLE
Add support for the FT232H based digilent cables and desync the config engine after programming

### DIFF
--- a/src/tools/fpgajtag/fpgajtag.c
+++ b/src/tools/fpgajtag/fpgajtag.c
@@ -418,7 +418,13 @@ static void init_device(int extra)
   write_item(DITEM(LOOPBACK_END, DIS_DIV_5));
   LOGNOTE("Set clock divisor");
   set_clock_divisor();
-  write_item(DITEM(SET_BITS_LOW, 0xe8, 0xeb, SET_BITS_HIGH, 0x20, 0x30));
+  if (extra)
+    write_item(DITEM(SET_BITS_LOW, 0xe8, 0xeb, SET_BITS_HIGH, 0x20, 0x30));
+  else
+    // FT232H-based Digilent cables (e.g. JTAG-HS2): ACBUS 0x00/0x60 per
+    // openFPGALoader's digilent_hs2 entry; with 0x20/0x30 the HS2 reads
+    // TDO stuck at 0 (all-zero IDCODEs)
+    write_item(DITEM(SET_BITS_LOW, 0xe8, 0xeb, SET_BITS_HIGH, 0x00, 0x60));
   if (extra)
     write_item(DITEM(SET_BITS_HIGH, 0x30, 0x00, SET_BITS_HIGH, 0x00, 0x00));
   LOGNOTE("For TAP to reset state.");

--- a/src/tools/fpgajtag/fpgajtag.c
+++ b/src/tools/fpgajtag/fpgajtag.c
@@ -1000,13 +1000,17 @@ int fpgajtag_main(char *bitstream)
   else
     log_debug("fpgajtag: bypass unknown %x", ret);
 
-  reset_mark_clock(0);
-  ret = readout_seq(jtag_index, rstatus, sizeof(uint32_t), -1);
-  int status = ret >> 8;
-  if (bitswap[M(ret)] != 2 || status != 0xf07910)
-    log_debug("[%s:%d] expect %x mismatch %x", __FUNCTION__, __LINE__, 0xf07910, ret);
-  log_debug("STATUS %08x done %x release_done %x eos %x startup_state %x", status, status & 0x4000, status & 0x2000,
-      status & 0x10, (status >> 18) & 7);
+  /*
+   * Do NOT re-read STAT here with the raw rstatus request: that request
+   * syncs the config packet processor to the JTAG port and (unlike
+   * read_config_reg) never desyncs it - and its malformed padding leaves
+   * the engine in a state where even an explicitly appended or standalone
+   * DESYNC is not honored. A synced engine ignores all other config
+   * interfaces including fabric ICAPE2 (UG470 port arbitration), so DFX
+   * designs and core selectors silently stop working after every JTAG
+   * push. STAT was already read (and properly desynced) via
+   * read_config_reg above; the engine must be left desynced here.
+   */
   access_mdm(0, 0, 1);
   // rescan = 1;
 


### PR DESCRIPTION
This PR contains a fix for the issue #240 and in addition it adds support for FT232H-based Digilent JTAG cables (such as the HS2, Rev. A). Please test with non-FT232H cables to ensure the addition does not break support for those. Or, cherry pick the issue fix only.

